### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Galaxykit
 
-Galaxykit is a client library for [galaxy\_ng](https://www.nytimes.com/2021/05/05/science/pasta-3d-flat.html), designed for use in internal testing.
+Galaxykit is a client library for [galaxy\_ng](https://github.com/ansible/galaxy_ng), designed for use in internal testing.
 
 It's intended to be a low-dependency and low-abstraction client for performing actions on a remote Automation Hub or galaxy\_ng instance.
 


### PR DESCRIPTION
I suppose I didn't have the galaxy_ng link in my clipboard when I initially wrote the readme...