### PR TITLE
Rename dockerutils

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -9,7 +9,7 @@ from simplejson import dumps
 import requests
 
 from . import containers
-from . import dockerutils
+from . import containerutils
 from . import groups
 from . import users
 
@@ -27,7 +27,7 @@ class GalaxyClient:
     headers = None
     galaxy_root = ""
     token = ""
-    docker_client = None
+    container_client = None
 
     def __init__(
         self,
@@ -74,8 +74,8 @@ class GalaxyClient:
                     or urlparse(self.galaxy_root).netloc.split(":")[0] + ":5001"
                 )
 
-                self.docker_client = dockerutils.DockerClient(
-                    (username, password),
+                self.container_client = containerutils.ContainerClient(
+                    (self.username, self.password),
                     container_engine,
                     container_registry,
                     tls_verify=container_tls_verify,
@@ -130,15 +130,15 @@ class GalaxyClient:
 
     def pull_image(self, image_name):
         """pulls an image with the given credentials"""
-        return self.docker_client.pull_image(image_name)
+        return self.container_client.pull_image(image_name)
 
     def tag_image(self, image_name, newtag):
         """tags a pulled image with the given newtag"""
-        return self.docker_client.tag_image(image_name, newtag)
+        return self.container_client.tag_image(image_name, newtag)
 
     def push_image(self, image_tag):
         """pushs a image"""
-        return self.docker_client.push_image(image_tag)
+        return self.container_client.push_image(image_tag)
 
     def get_or_create_user(
         self, username, password, group, fname="", lname="", email="", superuser=False

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -75,7 +75,7 @@ class GalaxyClient:
                 )
 
                 self.container_client = containerutils.ContainerClient(
-                    (self.username, self.password),
+                    (username, password),
                     container_engine,
                     container_registry,
                     tls_verify=container_tls_verify,

--- a/galaxykit/containerutils.py
+++ b/galaxykit/containerutils.py
@@ -56,19 +56,20 @@ class ContainerClient:
         else:
             run([self.engine, "pull", self.registry + image_name])
 
-    def tag_image(self, image_name, newtag):
+    def tag_image(self, image_name, image_tag):
         """
         Tags an image with the given tag (prepends the registry to the tag.)
         """
-        run(
-            [
-                self.engine,
-                "image",
-                "tag",
-                image_name,
-                f"{self.registry}/{newtag}",
-            ]
-        )
+        sep = "" if self.registry.endswith("/") else "/"
+        full_tag = f"{self.registry}{sep}{image_tag}"
+        run_args = [
+            self.engine,
+            "image",
+            "tag",
+            image_name,
+            full_tag,
+        ]
+        run(run_args)
 
     def push_image(self, image_tag):
         """

--- a/galaxykit/containerutils.py
+++ b/galaxykit/containerutils.py
@@ -1,13 +1,15 @@
 """
-Holds all of the functions used by GalaxyClient to handle Docker operations
+Holds all of the functions used by GalaxyClient to handle container operations.
+
+i.e. cli commands with podman, e.g. podman pull, podman image tag, etc.
 """
 
 from subprocess import run
 
 
-class DockerClient:
+class ContainerClient:
     """
-    DockerClient authenticates with the passed registry, as well as
+    ContainerClient authenticates with the passed registry, as well as
     provides utility functions for pushing, tagging, and pulling images.
     """
 
@@ -16,10 +18,14 @@ class DockerClient:
     tls_verify = True
 
     def __init__(
-        self, auth=None, engine="podman", registry="docker.io/library/", tls_verify=True
+        self,
+        auth=None,
+        engine="podman",
+        registry="docker.io/library/",
+        tls_verify=True,
     ):
         """
-        auth should be `(username, password)` for logging into the docker registry.
+        auth should be `(username, password)` for logging into the container registry.
 
         If not provided, then no login attempt is made.
         """
@@ -68,7 +74,7 @@ class DockerClient:
         """
         Pushes an image to the registry
         """
-        sep = '' if self.registry.endswith('/') else '/'
+        sep = "" if self.registry.endswith("/") else "/"
         full_tag = f"{self.registry}{sep}{image_tag}"
         run_args = [self.engine, "push", full_tag]
 


### PR DESCRIPTION
docker is a trademark, so I think it's better to avoid it in our codebase and use `container` in its place.