### PR TITLE
collection upload - use urljoin to prevent double slash

### DIFF
--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -121,6 +121,6 @@ def upload_artifact(
         "Authorization": f"Token {client.token}",
     }
 
-    n_url = f"{client.galaxy_root}/content/inbound-{artifact.namespace}/v3/artifacts/collections/"
+    n_url = urljoin(client.galaxy_root, f"content/inbound-{artifact.namespace}/v3/artifacts/collections/")
     resp = client._http("post", n_url, data=data, headers=headers)
     return resp


### PR DESCRIPTION
Related to https://github.com/ansible/ansible-hub-ui/pull/1082#issuecomment-942878791

`f"{galaxy_root}/content"` yields a string with a double slash when used with a `--server` value **with** a trailing slash (the default)
But double slashes don't seem to work with pulp-oci-images (or nginx?), leading to a html response (404)
=> using `urljoin` as elsewhere

---

Before/After:

```diff
 $ strace -e sendto,recvfrom -s 200  galaxykit -u admin -p admin collection upload
 ...
-sendto(3, "POST /api/automation-hub//content/inbound-admin/v3/artifacts/collections/"...
+sendto(3, "POST /api/automation-hub/content/inbound-admin/v3/artifacts/collections/"...
```