### PR TITLE
Bump version to v0.5.2, update CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Version 0.5.2
+Bugfix: fix double-slash in content URL
+## Version 0.5.1
+Bugfix: fix login to handle missing container utilities.
 ## Version 0.5.0
 Updates to namespaces and add collection functionality
 * List the metadata of a namespace

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name="galaxykit",
     packages={"galaxykit"},
     url="https://github.com/hendersonreed/galaxykit/",
-    version="0.5.0",
+    version="0.5.2",
     install_requires=["requests", "simplejson", "orionutils", "pyyaml"],
     extra_requires={"dev": ["pre-commit"]},
     entry_points={


### PR DESCRIPTION
The PR to release v0.5.1 never got merged in (my fault, I forgot to assign a reviewer and then forgot about it.)

There is a v0.5.1 version on PyPi though, we could elect to yank it afterwards if we want, because there's no way for anyone not intimate with the project to really know what code is in there.)

Anyways, this PR is just the formalities of bumping the version and adding to the changelog.