### PR TITLE
Add --ignore-certs argument to CLI

### DIFF
--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -54,7 +54,11 @@ def main():
     parser.add_argument("-u", "--username", type=str, action="store")
     parser.add_argument("-p", "--password", type=str, action="store")
     parser.add_argument(
-        "-c", "--ignore-certs", type=str, action="store", help="Ignore invalid SSL certificates"
+        "-c",
+        "--ignore_certs",
+        default=False,
+        action="store_true",
+        help="Ignore invalid SSL certificates",
     )
     parser.add_argument(
         "-s",
@@ -66,7 +70,8 @@ def main():
 
     args = parser.parse_args()
     ignore = args.ignore
-    client = GalaxyClient(args.server, (args.username, args.password))
+    https_verify = args.ignore_certs
+    client = GalaxyClient(args.server, (args.username, args.password), https_verify=https_verify)
     resp = None
 
     try:

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -55,7 +55,7 @@ def main():
     parser.add_argument("-p", "--password", type=str, action="store")
     parser.add_argument(
         "-c",
-        "--ignore_certs",
+        "--ignore-certs",
         default=False,
         action="store_true",
         help="Ignore invalid SSL certificates",

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -70,7 +70,7 @@ def main():
 
     args = parser.parse_args()
     ignore = args.ignore
-    https_verify = args.ignore_certs
+    https_verify = not args.ignore_certs
     client = GalaxyClient(args.server, (args.username, args.password), https_verify=https_verify)
     resp = None
 
@@ -81,9 +81,7 @@ def main():
                 print(format_list(resp["data"], "username"))
             elif args.operation == "create":
                 username, password = args.rest
-                created, resp = users.get_or_create_user(
-                    client, username, password, None
-                )
+                created, resp = users.get_or_create_user(client, username, password, None)
                 if created:
                     print("Created user", username)
                 else:
@@ -137,8 +135,7 @@ def main():
                 elif subop == "add":
                     groupname, perm = subopargs
                     perms = [
-                        p["permission"]
-                        for p in groups.get_permissions(client, groupname)["data"]
+                        p["permission"] for p in groups.get_permissions(client, groupname)["data"]
                     ]
                     perms = list(set(perms) | set([perm]))
                     resp = groups.set_permissions(client, groupname, perms)

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -54,6 +54,9 @@ def main():
     parser.add_argument("-u", "--username", type=str, action="store")
     parser.add_argument("-p", "--password", type=str, action="store")
     parser.add_argument(
+        "-c", "--ignore-certs", type=str, action="store", help="Ignore invalid SSL certificates"
+    )
+    parser.add_argument(
         "-s",
         "--server",
         type=str,


### PR DESCRIPTION
This argument is needed to have galaxykit work well against YOLO deployed instances that don't have secure SSL certificates installed.