### PR TITLE
galaxykit support for deletion of collections, namespaces, containers, etc.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+
+
+ * Support for deletion of Collections (both versions and whole), Namespaces, Containers, Container Images, Execution Enviroments Registry.
+
 ## Version 0.6.0
 * Add collection move function - accessible via `galaxykit collection move <namespace> <name>` which assumes collection version = 1.0.0 and the source repo = staging and the destination repo = published. Alternatively those arguments can be supplied, in that order (e.g. `galaxykit collection move admin collection_dep_a_asdfasdf 1.2.0 rejected published`.
 * Addition of `--ignore-certs` (short version is `-c`) to enable running against insecure instances of galaxy.

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -172,7 +172,12 @@ def delete_collection(client, namespace, collection, version):
     """
     Delete collection version
     """
-    delete_url = f"content/published/v3/collections/{namespace}/{collection}/versions/{version}"
-    return client.delete(delete_url, parse_json=False)
     
+    if version == None:
+        delete_url = f"/api/automation-hub/content/published/v3/collections/{namespace}/{collection}/"
+    else:
+        delete_url = f"content/published/v3/collections/{namespace}/{collection}/versions/{version}"
+
+    return client.delete(delete_url, parse_json=False)
+ 
     

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -174,7 +174,7 @@ def delete_collection(client, namespace, collection, version):
     """
     
     if version == None:
-        delete_url = f"/api/automation-hub/content/published/v3/collections/{namespace}/{collection}/"
+        delete_url = f"content/published/v3/collections/{namespace}/{collection}/"
     else:
         delete_url = f"content/published/v3/collections/{namespace}/{collection}/versions/{version}"
 

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -7,6 +7,7 @@ import os
 import json
 from time import sleep
 from urllib.parse import urljoin
+from pprint import pprint
 
 from orionutils.generator import build_collection
 from .client import GalaxyClientError
@@ -166,3 +167,12 @@ def move_collection(
             if timeout < 0:
                 raise
     return True
+
+def delete_collection(client, namespace, collection, version):
+    """
+    Delete collection version
+    """
+    delete_url = f"content/published/v3/collections/{namespace}/{collection}/versions/{version}"
+    res = client.delete(delete_url, parse_json=False)
+    #pprint(vars(res))
+    return res

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -173,6 +173,6 @@ def delete_collection(client, namespace, collection, version):
     Delete collection version
     """
     delete_url = f"content/published/v3/collections/{namespace}/{collection}/versions/{version}"
-    res = client.delete(delete_url, parse_json=False)
-    #pprint(vars(res))
-    return res
+    return client.delete(delete_url, parse_json=False)
+    
+    

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -244,7 +244,11 @@ def main():
                         client, namespace, collection_name, version, source, destination
                     )
             elif args.operation == "delete":
-                namespace, collection, version = args.rest
+                if len(args.rest) == 3:
+                    namespace, collection, version = args.rest
+                if len(args.rest) == 2:
+                    namespace, collection = args.rest
+                    version = None    
                 try:
                     resp = collections.delete_collection(client, namespace, collection, version)
                 except ValueError as e:

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -8,6 +8,7 @@ from . import collections
 from . import groups
 from . import namespaces
 from . import users
+from . import container_images
 
 EXIT_OK = 0
 EXIT_UNKNOWN_ERROR = 1
@@ -214,6 +215,18 @@ def main():
                         sys.exit(EXIT_NOT_FOUND)
             else:
                 print_unknown_error(args)
+
+        elif args.kind == "container-image":
+            if args.operation == "delete":
+                container, image  = args.rest
+                try:
+                    resp = container_images.delete_container(client, container, image)
+                except ValueError as e:
+                    if not args.ignore:
+                        print(e)
+                        sys.exit(EXIT_NOT_FOUND)
+            else:
+                print_unknown_error(args) 
 
         elif args.kind == "collection":
             if args.operation == "upload":

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -227,8 +227,17 @@ def main():
                     collections.move_collection(
                         client, namespace, collection_name, version, source, destination
                     )
+            elif args.operation == "delete":
+                namespace, collection, version = args.rest
+                try:
+                    resp = collections.delete_collection(client, namespace, collection, version)
+                except ValueError as e:
+                    if not args.ignore:
+                        print(e)
+                        sys.exit(EXIT_NOT_FOUND)
             else:
                 print_unknown_error(args)
+            
 
         elif args.kind == "url":
             if args.operation == "get":

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -167,8 +167,16 @@ def main():
                     (name,) = args.rest
                     group = None
                 resp = namespaces.create_namespace(client, name, group)
+
             elif args.operation == "delete":
-                raise NotImplementedError
+                (namespace,) = args.rest
+                try:
+                    resp = namespaces.delete_namespace(client, namespace)
+                except ValueError as e:
+                    if not args.ignore:
+                        print(e)
+                        sys.exit(EXIT_NOT_FOUND)
+
             elif args.operation == "groups":
                 raise NotImplementedError
             elif args.operation == "addgroup":

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -9,6 +9,7 @@ from . import groups
 from . import namespaces
 from . import users
 from . import container_images
+from . import registries
 
 EXIT_OK = 0
 EXIT_UNKNOWN_ERROR = 1
@@ -221,6 +222,18 @@ def main():
                 container, image  = args.rest
                 try:
                     resp = container_images.delete_container(client, container, image)
+                except ValueError as e:
+                    if not args.ignore:
+                        print(e)
+                        sys.exit(EXIT_NOT_FOUND)
+            else:
+                print_unknown_error(args) 
+
+        elif args.kind == "registry":
+            if args.operation == "delete":
+                (name,) = args.rest
+                try:
+                    resp = registries.delete_registry(client, name)
                 except ValueError as e:
                     if not args.ignore:
                         print(e)

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -169,9 +169,9 @@ def main():
                 resp = namespaces.create_namespace(client, name, group)
 
             elif args.operation == "delete":
-                (namespace,) = args.rest
+                (name,) = args.rest
                 try:
-                    resp = namespaces.delete_namespace(client, namespace)
+                    resp = namespaces.delete_namespace(client, name)
                 except ValueError as e:
                     if not args.ignore:
                         print(e)
@@ -204,6 +204,14 @@ def main():
                 else:
                     print("container readme takes either 1 or 2 parameters.")
                     sys.exit(EXIT_UNKNOWN_ERROR)
+            elif args.operation == "delete":
+                (name,) = args.rest
+                try:
+                    resp = containers.delete_container(client, name)
+                except ValueError as e:
+                    if not args.ignore:
+                        print(e)
+                        sys.exit(EXIT_NOT_FOUND)
             else:
                 print_unknown_error(args)
 

--- a/galaxykit/container_images.py
+++ b/galaxykit/container_images.py
@@ -1,0 +1,9 @@
+from pprint import pprint
+
+def delete_container(client, container, image):
+    """
+    Delete container image
+    """
+    delete_url = f"/api/automation-hub/_ui/v1/execution-environments/repositories/{container}/_content/images/{image}/"
+    return client.delete(delete_url, parse_json=False)
+    

--- a/galaxykit/container_images.py
+++ b/galaxykit/container_images.py
@@ -4,6 +4,6 @@ def delete_container(client, container, image):
     """
     Delete container image
     """
-    delete_url = f"/api/automation-hub/_ui/v1/execution-environments/repositories/{container}/_content/images/{image}/"
+    delete_url = f"_ui/v1/execution-environments/repositories/{container}/_content/images/{image}/"
     return client.delete(delete_url, parse_json=False)
     

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 def get_readme(client, container):
     """
     Returns a json response containing the readme
@@ -14,3 +16,13 @@ def set_readme(client, container, readme):
     resp = get_readme(client, container)
     resp["text"] = readme
     return client.put(url, resp)
+
+def delete_container(client, name):
+    """
+    Delete container
+    """
+    delete_url = f"/api/automation-hub/_ui/v1/execution-environments/repositories/{name}/"
+    return client.delete(delete_url, parse_json=False)
+    
+
+    

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -21,7 +21,7 @@ def delete_container(client, name):
     """
     Delete container
     """
-    delete_url = f"/api/automation-hub/_ui/v1/execution-environments/repositories/{name}/"
+    delete_url = f"_ui/v1/execution-environments/repositories/{name}/"
     return client.delete(delete_url, parse_json=False)
     
 

--- a/galaxykit/namespaces.py
+++ b/galaxykit/namespaces.py
@@ -1,4 +1,5 @@
 from . import groups
+from pprint import pprint
 
 
 def create_namespace(client, name, group):
@@ -83,6 +84,14 @@ def get_namespace_id(client, name):
         return resp["data"][0]["id"]
     else:
         raise ValueError(f"No namespace '{name}' found.")
+
+def delete_namespace(client, namespace):
+    """
+    Delete namespace
+    """
+    delete_url = f"/api/automation-hub/_ui/v1/namespaces/{namespace}"
+    res = client.delete(delete_url, parse_json=False)
+    return res
 
 
     

--- a/galaxykit/namespaces.py
+++ b/galaxykit/namespaces.py
@@ -89,7 +89,7 @@ def delete_namespace(client, name):
     """
     Delete namespace
     """
-    delete_url = f"/api/automation-hub/_ui/v1/namespaces/{name}"
+    delete_url = f"_ui/v1/namespaces/{name}"
     return client.delete(delete_url, parse_json=False)
     
     

--- a/galaxykit/namespaces.py
+++ b/galaxykit/namespaces.py
@@ -85,13 +85,14 @@ def get_namespace_id(client, name):
     else:
         raise ValueError(f"No namespace '{name}' found.")
 
-def delete_namespace(client, namespace):
+def delete_namespace(client, name):
     """
     Delete namespace
     """
-    delete_url = f"/api/automation-hub/_ui/v1/namespaces/{namespace}"
-    res = client.delete(delete_url, parse_json=False)
-    return res
+    delete_url = f"/api/automation-hub/_ui/v1/namespaces/{name}"
+    return client.delete(delete_url, parse_json=False)
+    
+    
 
 
     

--- a/galaxykit/namespaces.py
+++ b/galaxykit/namespaces.py
@@ -83,3 +83,6 @@ def get_namespace_id(client, name):
         return resp["data"][0]["id"]
     else:
         raise ValueError(f"No namespace '{name}' found.")
+
+
+    

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -1,0 +1,24 @@
+from pprint import pprint
+
+
+def get_registry_pk(client, name):
+    """
+    Returns the primary key for a given registry name
+    """
+    user_url = f"/api/automation-hub/_ui/v1/execution-environments/registries/?name={name}"
+    resp = client.get(user_url)
+    if resp["data"]:
+        return resp["data"][0]["pk"]
+    else:
+        raise ValueError(f"No registry '{name}' found.")
+
+def delete_registry(client, name):
+    """
+    Delete registry
+    """
+    pk = get_registry_pk(client, name)
+    delete_url = f"/api/automation-hub/_ui/v1/execution-environments/registries/{pk}/"
+    return client.delete(delete_url, parse_json=False)
+    
+
+    

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -5,7 +5,7 @@ def get_registry_pk(client, name):
     """
     Returns the primary key for a given registry name
     """
-    user_url = f"/api/automation-hub/_ui/v1/execution-environments/registries/?name={name}"
+    user_url = f"_ui/v1/execution-environments/registries/?name={name}"
     resp = client.get(user_url)
     if resp["data"]:
         return resp["data"][0]["pk"]
@@ -17,7 +17,7 @@ def delete_registry(client, name):
     Delete registry
     """
     pk = get_registry_pk(client, name)
-    delete_url = f"/api/automation-hub/_ui/v1/execution-environments/registries/{pk}/"
+    delete_url = f"_ui/v1/execution-environments/registries/{pk}/"
     return client.delete(delete_url, parse_json=False)
     
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1190

galaxykit CLI already supports `user delete <name>` and `group delete <name>`,

implement the missing deletions:

    `collection delete <name> [<version>]` - collections and collection versions
    `namespace delete <name>` - namespaces
    `container delete <name>` - local and remote EE repositories
    container manifest deletion (`container-image delete <container/name> <tag | sha>`?)
    EE registry deletion (`registry delete <name>`?)
