### PR TITLE
galaxykit: add missing commands

### DIFF
--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -121,15 +121,7 @@ def main():
                     username, groupname = subopargs
                     user_data = users.get_user(client, username)
                     group_id = groups.get_group_id(client, groupname)
-                    old_groups = user_data["groups"]
-                    new_groups = []
-
-                    for group in old_groups:
-                        if group['id'] != group_id:
-                            new_groups.append(group)
-                    
-                    user_data["groups"] = new_groups
-
+                    user_data["groups"] = list(filter(lambda group: group['id'] != group_id, user_data["groups"]))
                     pprint(user_data)
                     resp = users.update_user(client, user_data)
             else:

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -261,9 +261,9 @@ def main():
                         print(e)
                         sys.exit(EXIT_NOT_FOUND)
             elif args.operation == "create":
-                name, url, username, password = args.rest
+                name, url = args.rest
                 try:
-                    resp = registries.create_registry(client, name, url, username, password)
+                    resp = registries.create_registry(client, name, url)
                 except ValueError as e:
                     if not args.ignore:
                         print(e)

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -122,7 +122,6 @@ def main():
                     user_data = users.get_user(client, username)
                     group_id = groups.get_group_id(client, groupname)
                     user_data["groups"] = list(filter(lambda group: group['id'] != group_id, user_data["groups"]))
-                    pprint(user_data)
                     resp = users.update_user(client, user_data)
             else:
                 print_unknown_error(args)

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -121,7 +121,11 @@ def main():
                     username, groupname = subopargs
                     user_data = users.get_user(client, username)
                     group_id = groups.get_group_id(client, groupname)
-                    user_data["groups"] = list(filter(lambda group: group['id'] != group_id, user_data["groups"]))
+                    user_data["groups"] = list(
+                        filter(
+                            lambda group: group["id"] != group_id, user_data["groups"]
+                        )
+                    )
                     resp = users.update_user(client, user_data)
             else:
                 print_unknown_error(args)
@@ -230,7 +234,9 @@ def main():
             elif args.operation == "create":
                 name, upstream_name, registry = args.rest
                 try:
-                    resp = containers.create_container(client, name, upstream_name, registry)
+                    resp = containers.create_container(
+                        client, name, upstream_name, registry
+                    )
                 except ValueError as e:
                     if not args.ignore:
                         print(e)

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -226,6 +226,7 @@ def main():
                 else:
                     print("container readme takes either 1 or 2 parameters.")
                     sys.exit(EXIT_UNKNOWN_ERROR)
+
             elif args.operation == "delete":
                 (name,) = args.rest
                 try:
@@ -234,6 +235,16 @@ def main():
                     if not args.ignore:
                         print(e)
                         sys.exit(EXIT_NOT_FOUND)
+
+            elif args.operation == "create":
+                name, upstream_name, registry = args.rest
+                try:
+                    resp = containers.create_container(client, name, upstream_name, registry)
+                except ValueError as e:
+                    if not args.ignore:
+                        print(e)
+                        sys.exit(EXIT_NOT_FOUND)
+
             else:
                 print_unknown_error(args)
 
@@ -258,7 +269,6 @@ def main():
                     if not args.ignore:
                         print(e)
                         sys.exit(EXIT_NOT_FOUND)
-
             elif args.operation == "create":
                 name, url, username, password = args.rest
                 try:
@@ -267,7 +277,6 @@ def main():
                     if not args.ignore:
                         print(e)
                         sys.exit(EXIT_NOT_FOUND)
-
             else:
                 print_unknown_error(args)
 

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 import json
+from pprint import pprint
 
 from .client import GalaxyClient, GalaxyClientError
 from . import containers
@@ -102,6 +103,7 @@ def main():
                         sys.exit(EXIT_NOT_FOUND)
             elif args.operation == "group":
                 subop, *subopargs = args.rest
+
                 if subop == "add":
                     username, groupname = subopargs
                     user_data = users.get_user(client, username)
@@ -113,6 +115,22 @@ def main():
                             "pulp_href": f"/pulp/api/v3/groups/{group_id}",
                         }
                     )
+                    resp = users.update_user(client, user_data)
+
+                if subop == "remove":
+                    username, groupname = subopargs
+                    user_data = users.get_user(client, username)
+                    group_id = groups.get_group_id(client, groupname)
+                    old_groups = user_data["groups"]
+                    new_groups = []
+
+                    for group in old_groups:
+                        if group['id'] != group_id:
+                            new_groups.append(group)
+                    
+                    user_data["groups"] = new_groups
+
+                    pprint(user_data)
                     resp = users.update_user(client, user_data)
             else:
                 print_unknown_error(args)
@@ -240,6 +258,16 @@ def main():
                     if not args.ignore:
                         print(e)
                         sys.exit(EXIT_NOT_FOUND)
+
+            elif args.operation == "create":
+                name, url, username, password = args.rest
+                try:
+                    resp = registries.create_registry(client, name, url, username, password)
+                except ValueError as e:
+                    if not args.ignore:
+                        print(e)
+                        sys.exit(EXIT_NOT_FOUND)
+
             else:
                 print_unknown_error(args)
 

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -36,9 +36,9 @@ def create_container(client, name, upstream_name, registry):
     create_url = f"_ui/v1/execution-environments/remotes/"
     registry_id = registries.get_registry_pk(client, registry)
     data = {
-        'name'              : name,
-        'upstream_name'     : upstream_name,
-        'registry'          : registry_id
+        'name': name,
+        'upstream_name': upstream_name,
+        'registry': registry_id
     }
     return client.post(create_url, data)
     

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -1,4 +1,5 @@
 from pprint import pprint
+from . import registries
 
 
 def get_readme(client, container):
@@ -25,3 +26,22 @@ def delete_container(client, name):
     """
     delete_url = f"_ui/v1/execution-environments/repositories/{name}/"
     return client.delete(delete_url, parse_json=False)
+<<<<<<< HEAD
+=======
+
+def create_container(client, name, upstream_name, registry):
+    """
+    Create container
+    """
+    create_url = f"_ui/v1/execution-environments/remotes/"
+    registry_id = registries.get_registry_pk(client, registry)
+    data = {
+        'name'              : name,
+        'upstream_name'     : upstream_name,
+        'registry'          : registry_id
+    }
+    return client.post(create_url, data)
+    
+
+    
+>>>>>>> 2a77028 (Create EE container)

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -42,4 +42,3 @@ def create_container(client, name, upstream_name, registry):
         "include_tags": [],
     }
     return client.post(create_url, data)
-

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -38,7 +38,9 @@ def create_container(client, name, upstream_name, registry):
     data = {
         'name': name,
         'upstream_name': upstream_name,
-        'registry': registry_id
+        'registry': registry_id,
+        'exclude_tags': [],
+        'include_tags': []
     }
     return client.post(create_url, data)
     

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -26,8 +26,7 @@ def delete_container(client, name):
     """
     delete_url = f"_ui/v1/execution-environments/repositories/{name}/"
     return client.delete(delete_url, parse_json=False)
-<<<<<<< HEAD
-=======
+
 
 def create_container(client, name, upstream_name, registry):
     """
@@ -36,14 +35,11 @@ def create_container(client, name, upstream_name, registry):
     create_url = f"_ui/v1/execution-environments/remotes/"
     registry_id = registries.get_registry_pk(client, registry)
     data = {
-        'name': name,
-        'upstream_name': upstream_name,
-        'registry': registry_id,
-        'exclude_tags': [],
-        'include_tags': []
+        "name": name,
+        "upstream_name": upstream_name,
+        "registry": registry_id,
+        "exclude_tags": [],
+        "include_tags": [],
     }
     return client.post(create_url, data)
-    
 
-    
->>>>>>> 2a77028 (Create EE container)

--- a/galaxykit/groups.py
+++ b/galaxykit/groups.py
@@ -73,7 +73,6 @@ def delete_permission(client, group_name, permission):
     group_id = get_group(client, group_name)["id"]
     permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
     resp = client.get(permissions_url)
-    pprint(resp)
     for perm in resp["data"]:
         if perm["permission"] == permission:
             perm_id = perm["id"]

--- a/galaxykit/groups.py
+++ b/galaxykit/groups.py
@@ -1,5 +1,6 @@
 import requests
 import json
+from pprint import pprint
 
 
 def get_group(client, group_name):
@@ -72,6 +73,7 @@ def delete_permission(client, group_name, permission):
     group_id = get_group(client, group_name)["id"]
     permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
     resp = client.get(permissions_url)
+    pprint(resp)
     for perm in resp["data"]:
         if perm["permission"] == permission:
             perm_id = perm["id"]

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -21,14 +21,15 @@ def delete_registry(client, name):
     delete_url = f"_ui/v1/execution-environments/registries/{pk}/"
     return client.delete(delete_url, parse_json=False)
 
+
 def create_registry(client, name, url):
     """
     Create registry
     """
     post_url = f"_ui/v1/execution-environments/registries/"
     registry = {
-        'name': name,
-        'url': url,
-    }   
+        "name": name,
+        "url": url,
+    }
     return client.post(post_url, registry)
-    
+

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -20,3 +20,18 @@ def delete_registry(client, name):
     pk = get_registry_pk(client, name)
     delete_url = f"_ui/v1/execution-environments/registries/{pk}/"
     return client.delete(delete_url, parse_json=False)
+
+
+def create_registry(client, name, url, username, password):
+    """
+    Create registry
+    """
+    post_url = f"_ui/v1/execution-environments/registries/"
+    registry = {
+        'name'          : name,
+        'url'           : url,
+        'username'      : username,
+        'password'      : password
+    }   
+    return client.post(post_url, registry)
+    

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -28,10 +28,10 @@ def create_registry(client, name, url, username, password):
     """
     post_url = f"_ui/v1/execution-environments/registries/"
     registry = {
-        'name'          : name,
-        'url'           : url,
-        'username'      : username,
-        'password'      : password
+        'name': name,
+        'url': url,
+        'username': username,
+        'password': password
     }   
     return client.post(post_url, registry)
     

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -21,8 +21,7 @@ def delete_registry(client, name):
     delete_url = f"_ui/v1/execution-environments/registries/{pk}/"
     return client.delete(delete_url, parse_json=False)
 
-
-def create_registry(client, name, url, username, password):
+def create_registry(client, name, url):
     """
     Create registry
     """
@@ -30,8 +29,6 @@ def create_registry(client, name, url, username, password):
     registry = {
         'name': name,
         'url': url,
-        'username': username,
-        'password': password
     }   
     return client.post(post_url, registry)
     

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -32,4 +32,3 @@ def create_registry(client, name, url):
         "url": url,
     }
     return client.post(post_url, registry)
-

--- a/galaxykit/users.py
+++ b/galaxykit/users.py
@@ -69,6 +69,7 @@ def create_user(
 def update_user(client, user):
     return client.put(f"_ui/v1/users/{user['id']}/", user)
 
+
 def delete_user(client, user):
     user_id = get_user_id(client, user)
     delete_url = f"_ui/v1/users/{user_id}/"

--- a/galaxykit/users.py
+++ b/galaxykit/users.py
@@ -69,7 +69,6 @@ def create_user(
 def update_user(client, user):
     return client.put(f"_ui/v1/users/{user['id']}/", user)
 
-
 def delete_user(client, user):
     user_id = get_user_id(client, user)
     delete_url = f"_ui/v1/users/{user_id}/"


### PR DESCRIPTION
[AAH-1193](https://issues.redhat.com/browse/AAH-1193)

(related to [AAH-1190](https://issues.redhat.com/browse/AAH-1190), [AAH-1191](https://issues.redhat.com/browse/AAH-1191); dependency of [AAH-1192](https://issues.redhat.com/browse/AAH-1192))

Add missing galaxykit commands identified in [AAH-1192](https://issues.redhat.com/browse/AAH-1192) as things we're triggering in the UI from unrelated tests:

    `user group remove <user> <group>` (corresponding `user group add` already exists)
    remote registry creation (`registry create <name> <url>`? - sync name deletion in with [AAH-1190](https://issues.redhat.com/browse/AAH-1190))
    remote container addition (`container remote create ...`? - sync optional params with [AAH-1191](https://issues.redhat.com/browse/AAH-1191))
    sync remote container (`container sync <name>`?) (might not be needed if we can sync on create, but nice to have anyway)

(and update [AAH-1192](https://issues.redhat.com/browse/AAH-1192) with the right command invocations where missing)