### PR TITLE
Use `args.ignore` over removed `ignore`

### DIFF
--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -359,9 +359,9 @@ def main():
             print(f"Unknown resource type '{args.kind}'")
             sys.exit(EXIT_UNKNOWN_ERROR)
 
-        if resp and not ignore:
+        if resp and not args.ignore:
             report_error(resp)
 
     except GalaxyClientError:
-        if not ignore:
+        if not args.ignore:
             raise


### PR DESCRIPTION
#28 [removes](https://github.com/ansible/galaxykit/pull/28/commits/6505e881a6a3c9d6ed9d85e70dee0e449132a3aa#diff-01476cd0d6f14f70729794bc9a0692c34ebc8df69671f2d52b5837aa8555a5e6L74) the `ignore = args.ignore` shortcut in `command.py`,

but we still have 2 uses of `ignore`: (from https://github.com/ansible/ansible-hub-ui/runs/5531062483?check_suite_focus=true)

```
$ galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin user list
admin id=1 date_joined=2022-03-14T01:26:56.61312Z is_superuser=True auth_provider=['django']
Traceback (most recent call last):
  File "/home/runner/.local/bin/galaxykit", line 8, in <module>
    sys.exit(main())
  File "/home/runner/.local/lib/python3.8/site-packages/galaxykit/command.py", line 362, in main
    if resp and not ignore:
NameError: name 'ignore' is not defined
Error: Process completed with exit code 1.
```

=> changing to use `args.ignore` :)