### PR TITLE
Fix github action - allow the workflow to add suggestions, not just warnings

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -19,4 +19,5 @@ jobs:
       if: steps.action_black.outputs.is_formatted == 'true'
       uses: reviewdog/action-suggester@v1
       with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         tool_name: "black"


### PR DESCRIPTION
followup to #33 - the workflow should add suggestions, not warnings,
but according to the error in https://github.com/ansible/galaxykit/runs/5477569424?check_suite_focus=true#step:5:182 ,
action-suggester doesn't have permissions, so it just adds warnings like in https://github.com/ansible/galaxykit/pull/31/commits/222d4338c1ab84275f8b4939436bf8bb88932067#diff-81734a16c3192d652a251f8089f11809bf829d09e91581c06e98aea6577977d1R35

I *think* this should fix it, the input defaults to something else in https://github.com/reviewdog/action-suggester/blob/master/action.yml#L5
Either that, or this is about `pull_request` vs `pull_request_target https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target

Cc @hendersonreed , I knew it couldn't be this easy :) So, this is attempt n. 2, the third would be pull_request_target, and then giving up and just making it fail on errors :)