### PR TITLE
feature/rbac-roles - add role commands; namespaces.addgroup - use object_roles, not object_permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 # Editors
 .vscode/
 .idea/
+.*.sw[po]

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -254,12 +254,6 @@ class GalaxyClient:
         """
         return groups.delete_group(self, group_name)
 
-    def set_permissions(self, group_name, permissions):
-        """
-        Assigns the given permissions to the group
-        """
-        return groups.set_permissions(self, group_name, permissions)
-
     def get_container_readme(self, container):
         return containers.get_readme(self, container)
 

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -290,6 +290,7 @@ KIND_OPS = {
                     "--permissions": {
                         "help": "Comma-separated list of permissions",
                     },
+                    "-p": {"dest": "permissions"},
                 },
             },
             "delete": {

--- a/galaxykit/groups.py
+++ b/galaxykit/groups.py
@@ -1,6 +1,4 @@
-import requests
-import json
-from pprint import pprint
+from . import roles
 
 
 def get_group(client, group_name):
@@ -38,46 +36,49 @@ def delete_group(client, group_name):
     return client.delete(delete_url, parse_json=False)
 
 
-def get_permissions(client, group_name):
-    group_id = get_group(client, group_name)["id"]
-    permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
-    return client.get(permissions_url)
+def get_roles(client, group_name):
+    group_id = get_group_id(client, group_name)
+    roles_url = f"pulp/api/v3/groups/{group_id}/roles/?content_object=null"
+    return client.get(roles_url)
 
 
-def set_permissions(client, group_name, permissions):
+def add_role(client, group_name, role_name):
     """
-    Assigns the given permissions to the group.
-    `permissions` must be a list of strings, each one recognized as a permission by the backend. See
-    them listed at the link below:
-    https://github.com/ansible/galaxy_ng/blob/ca503375077a225a5fb215e6fb2c6ae47e09cfd7/galaxy_ng/app/api/ui/serializers/user.py#L122
-
-    Container permissions are in another file:
-    https://github.com/ansible/galaxy_ng/blob/009385fb3a1a34d1df9ff369e2e15c3fa27869b3/galaxy_ng/app/access_control/statements/pulp_container.py#L139
-
-    The permissions are the ones that match the "namespace.permission-name" format.
-
+    Assigns the given role to the group.
+    The roles should match the "galaxy.role-name" format.
     """
-    group_id = get_group(client, group_name)["id"]
-    permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
-    for perm in permissions:
-        payload = {"permission": perm}
-        client.post(permissions_url, payload)
-        # TODO: Check the results of each and aggregate for a return value
+    group_id = get_group_id(client, group_name)
+    roles_url = f"pulp/api/v3/groups/{group_id}/roles/"
+    payload = {
+        "content_object": None,
+        "role": role_name,
+    }
+    return client.post(roles_url, payload)
 
 
-def delete_permission(client, group_name, permission):
+def get_group_role_id(client, group_name, role_name):
     """
-    Removes a permission from a group.
-
+    Returns the id for a given role in a group
     """
-    group_id = get_group(client, group_name)["id"]
-    permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
-    resp = client.get(permissions_url)
-    for perm in resp["data"]:
-        if perm["permission"] == permission:
-            perm_id = perm["id"]
-            perm_url = f"_ui/v1/groups/{group_id}/model-permissions/{perm_id}/"
-            client.delete(perm_url, parse_json=False)
+    group_id = get_group_id(client, group_name)
+    roles_url = (
+        f"pulp/api/v3/groups/{group_id}/roles/?content_object=null&role={role_name}"
+    )
+    resp = client.get(roles_url)
+    if resp["results"]:
+        return roles.pulp_href_to_id(resp["results"][0]["pulp_href"])
+    else:
+        raise ValueError(f"No role '{role_name}' found in group '{group_name}'.")
+
+
+def remove_role(client, group_name, role_name):
+    """
+    Removes a role from a group.
+    """
+    group_id = get_group_id(client, group_name)
+    role_id = get_group_role_id(client, group_name, role_name)
+    roles_url = f"pulp/api/v3/groups/{group_id}/roles/{role_id}/"
+    return client.delete(roles_url, parse_json=False)
 
 
 def get_group_list(client):

--- a/galaxykit/namespaces.py
+++ b/galaxykit/namespaces.py
@@ -59,7 +59,7 @@ def add_group(client, ns_name, group_name):
         {
             "id": group["id"],
             "name": group["name"],
-            "object_permissions": ["change_namespace", "upload_to_namespace"],
+            "object_roles": ["galaxy.namespace_owner"],
         }
     )
     return update_namespace(client, namespace)

--- a/galaxykit/roles.py
+++ b/galaxykit/roles.py
@@ -1,0 +1,93 @@
+import re
+
+
+def pulp_href_to_id(href):
+    uuid_regex = "[0-9a-f]{8}-[0-9a-uf]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+    for section in href.split("/"):
+        if re.match(uuid_regex, section):
+            return section
+
+    return None
+
+
+def get_role_list(client):
+    """
+    Returns list of galaxy rbac roles in the system
+    """
+    return client.get(f"pulp/api/v3/roles/?name__startswith=galaxy.")
+
+
+def get_role(client, role_name):
+    """
+    Returns the data of the role with role_name
+    """
+    roles_url = f"pulp/api/v3/roles/?name={role_name}"
+    return client.get(roles_url)["results"][0]
+
+
+def get_role_id(client, role_name):
+    """
+    Returns the id for a given role
+    """
+    roles_url = f"pulp/api/v3/roles/?name={role_name}"
+    resp = client.get(roles_url)
+    if resp["results"]:
+        return pulp_href_to_id(resp["results"][0]["pulp_href"])
+    else:
+        raise ValueError(f"No role '{role_name}' found.")
+
+
+def create_role(client, role_name, description, permissions):
+    """
+    Creates an rbac role
+    """
+    payload = {
+        "description": description,
+        "name": role_name,
+        "permissions": permissions or [],
+    }
+    resp = client.post("pulp/api/v3/roles/", payload, parse_json=False)
+    if resp.status_code == 400:
+        raise ValueError(resp.json())
+    return resp
+
+
+def delete_role(client, role_name):
+    role_id = get_role_id(client, role_name)
+    delete_url = f"pulp/api/v3/roles/{role_id}/"
+    return client.delete(delete_url, parse_json=False)
+
+
+# `permissions` must be a list of strings, each one recognized as a permission by the backend.
+#
+# See them listed at the link below:
+# https://github.com/ansible/galaxy_ng/blob/ca503375077a225a5fb215e6fb2c6ae47e09cfd7/galaxy_ng/app/api/ui/serializers/user.py#L122
+#
+# Container permissions are in another file:
+# https://github.com/ansible/galaxy_ng/blob/009385fb3a1a34d1df9ff369e2e15c3fa27869b3/galaxy_ng/app/access_control/statements/pulp_container.py#L139
+#
+# The permissions are the ones that match the "namespace.permission-name" format.
+
+
+def get_permissions(client, role_name):
+    return get_role(client, role_name)["permissions"]
+
+
+def set_permissions(client, role_name, add_permissions=[], remove_permissions=[]):
+    """
+    Assigns the given permissions to the role.
+    """
+    role = get_role(client, role_name)
+    role_id = pulp_href_to_id(role["pulp_href"])
+    role_url = f"pulp/api/v3/roles/{role_id}/"
+
+    permissions = set(role["permissions"])
+    permissions = permissions | set(add_permissions)
+    permissions = permissions - set(remove_permissions)
+
+    payload = {"permissions": list(permissions)}
+    resp = client.patch(role_url, payload, parse_json=False)
+    if resp.status_code == 400:
+        raise ValueError(resp.json())
+    return resp

--- a/galaxykit/roles.py
+++ b/galaxykit/roles.py
@@ -2,7 +2,7 @@ import re
 
 
 def pulp_href_to_id(href):
-    uuid_regex = "[0-9a-f]{8}-[0-9a-uf]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    uuid_regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
     for section in href.split("/"):
         if re.match(uuid_regex, section):


### PR DESCRIPTION
(draft until the feature/rbac-roles galaxy_ng & ansible-hub-ui branches get merged in master)

This addresses compatibility with the new (4.6+) rbac roles:

[AAH-1691](https://issues.redhat.com/browse/AAH-1691):
`galaxykit role list`
`galaxykit role create <rolename> <description> --permissions <permissions> `
`galaxykit role delete <rolename>`
`galaxykit role perm list <rolename>`
`galaxykit role perm add <rolename> <perm>`
`galaxykit role perm remove <rolename> <perm>`

[AAH-1692](https://issues.redhat.com/browse/AAH-1692):
`galaxykit group role add <group> <role>`
`galaxykit group role remove <group> <role>`

No-Issue:
make `galaxykit namespace addgroup <namespace> <group>` work again, by sending `object_roles` instead of `object_permissions`

Removed:
`galaxykit group perm list <groupname>`
`galaxykit group perm add <groupname> <perm>`
`galaxykit group perm remove <groupname> <perm>`

Removed methods:
* `groups.get_permissions` (replaced by `roles.get_permissions`)
* `groups.set_permissions` (replaced by `roles.set_permissions` with `add_permissions=[]`)
* `groups.delete_permission` (replaced by `roles.set_permissions` with `remove_permissions=[]`)
* `client.set_permissions` (not sure if unused, or if we just need to change it to call `roles.set_permissions` instead of `groups.set_permissions`)

---

Also adding vim swapfiles to gitignore,
and adding a `client.patch` method, used by role perm add/remove.