### PR TITLE
container create: add include_tags=latest

### DIFF
--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -39,6 +39,6 @@ def create_container(client, name, upstream_name, registry):
         "upstream_name": upstream_name,
         "registry": registry_id,
         "exclude_tags": [],
-        "include_tags": [],
+        "include_tags": ['latest'],
     }
     return client.post(create_url, data)


### PR DESCRIPTION
without include_tags, any remove containers added using `galaxykit container create` are downloading all the versions - limiting to just the latest version.

(we should make these configurable after the command refactor, but for now, hardcoding to `latest`)