### PR TITLE
Use user+pass to fetch an auth_token from Keycloak 

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -77,30 +77,24 @@ class GalaxyClient:
                 # access token up front, so we have to create one via user+pass.
                 # Does this work on real SSO? I have no idea.
 
-                headers = {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                }
+                headers = {'Content-Type': 'application/x-www-form-urlencoded'}
                 ds = {
-                    'client_id': 'cloud-services',
-                    'username': self.username,
-                    'password': self.password,
-                    'grant_type': 'password'
+                    "client_id": "cloud-services",
+                    "username": self.username,
+                    "password": self.password,
+                    "grant_type": "password"
                 }
-                rr = requests.post(
-                    self.auth_url,
-                    headers=headers,
-                    data=ds
-                )
+                rr = requests.post(self.auth_url, headers=headers, data=ds)
                 if rr.status_code != 200:
                     raise Exception(rr.text)
-                self.token_type = 'Bearer'
+                self.token_type = "Bearer"
                 try:
                     jdata = rr.json()
                 except Exception as e:
                     raise Exception(rr.text)
-                if 'access_token' not in jdata:
+                if "access_token" not in jdata:
                     raise Exception(rr.text)
-                self.token = jdata['access_token']
+                self.token = jdata["access_token"]
 
             elif self.token and self.auth_url:
                 payload = "grant_type=refresh_token&client_id=%s&refresh_token=%s" % (

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -73,16 +73,16 @@ class GalaxyClient:
             if not self.token and self.auth_url:
 
                 # https://developers.redhat.com/blog/2020/01/29/api-login-and-jwt-token-generation-using-keycloak
-                # When testing ephemeral environments, we won't have the 
+                # When testing ephemeral environments, we won't have the
                 # access token up front, so we have to create one via user+pass.
                 # Does this work on real SSO? I have no idea.
 
-                headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+                headers = {"Content-Type": "application/x-www-form-urlencoded"}
                 ds = {
                     "client_id": "cloud-services",
                     "username": self.username,
                     "password": self.password,
-                    "grant_type": "password"
+                    "grant_type": "password",
                 }
                 rr = requests.post(self.auth_url, headers=headers, data=ds)
                 if rr.status_code != 200:

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -76,7 +76,13 @@ def main():
     args = parser.parse_args()
     https_verify = not args.ignore_certs
 
-    if args.token:
+    if args.auth_url and not args.token:
+        creds = {
+            "auth_url": args.auth_url,
+            "username": args.username,
+            "password": args.password,
+        }
+    elif args.token:
         creds = {
             "token": args.token,
         }


### PR DESCRIPTION
UI testing calls galaxykit to create and cleanup artifacts. Galaxykit currently requires a predefined access_token., however we won't have this information during ephemeral testing because it's a brand new environment and there's no time where a human can go into the UI and generate it. This PR allows galaxykit to attempt to query keycloak with the user+pass to get an access token.