### PR TITLE
Added support for upload exact collection version

### DIFF
--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -18,11 +18,16 @@ def collection_info(client, repository, namespace, collection_name, version):
     return client.get(url)
 
 
-def upload_test_collection(client, namespace=None, collection_name=None):
+def upload_test_collection(
+    client, namespace=None, collection_name=None, version="1.0.0"
+):
     """
     Uploads a test collection generated with orionutils
     """
-    config = {"namespace": namespace or client.username}
+    config = {
+        "namespace": namespace or client.username,
+        "version": version,
+    }
     if collection_name is not None:
         config["name"] = collection_name
     # cloud importer config requires at least one tag

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -302,13 +302,23 @@ def main():
         elif args.kind == "collection":
             if args.operation == "upload":
                 if len(args.rest) == 0:
-                    (namespace, collection_name) = (client.username, None)
-                else:
+                    (namespace, collection_name, version) = (
+                        client.username,
+                        None,
+                        None,
+                    )
+                elif len(args.rest) == 2:
                     (namespace, collection_name) = args.rest
+                    version = "1.0.0"
+                else:
+                    (namespace, collection_name, version) = args.rest
 
                 resp = namespaces.create_namespace(client, namespace, None)
                 artifact = collections.upload_test_collection(
-                    client, namespace=namespace, collection_name=collection_name
+                    client,
+                    namespace=namespace,
+                    collection_name=collection_name,
+                    version=version,
                 )
                 print(json.dumps(artifact))
             elif args.operation == "move":


### PR DESCRIPTION
Issue: #43 
Issue: AAH-1603

Need: https://github.com/ansible/ansible-hub-ui/pull/2069

This small pr allows galaxykit to upload exact collection version. This enable to have multiple versions created in a collection and helps with testing on a boarder spectrum of data.

Usage:
The command remains the same for `collection upload` except when supplied 3 params the last param is the version number. Examples:
```shell
# Works as before
galaxykit collection upload
# Works as before (creating a collection with the 1.0.0 version)
galaxykit collection upload my_namespace my_collection
# NEW: Creates the collection but with version numbers
# (allowing to create multiple versions of the collection)
galaxykit collection upload my_namespace my_collection 2.0.0
galaxykit collection upload my_namespace my_collection 2.1.0
```