### PR TITLE
command.py: use argparse subparsers

### DIFF
--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -54,14 +54,17 @@ KIND_OPS = {
                     "namespace": {
                         "help": "Collection namespace (optional, defaults to --username)",
                         "nargs": "?",
+                        "default": None,
                     },
                     "collection_name": {
                         "help": "Collection name (optional, randomly generated)",
                         "nargs": "?",
+                        "default": None,
                     },
                     "version": {
                         "help": "Version (optional, defaults to 1.0.0)",
                         "nargs": "?",
+                        "default": "1.0.0",
                     },
                 },
             },
@@ -69,23 +72,23 @@ KIND_OPS = {
                 "args": {
                     "namespace": {},
                     "collection_name": {},
-                    "version": {"nargs": "?"},
-                    "source": {"nargs": "?"},
-                    "destination": {"nargs": "?"},
+                    "version": {"nargs": "?", "default": "1.0.0"},
+                    "source": {"nargs": "?", "default": "staging"},
+                    "destination": {"nargs": "?", "default": "published"},
                 },
             },
             "delete": {
                 "args": {
                     "namespace": {},
                     "collection": {},
-                    "version": {"nargs": "?"},
-                    "repository": {"nargs": "?"},
+                    "version": {"nargs": "?", "default": None},
+                    "repository": {"nargs": "?", "default": "published"},
                 },
             },
             "download": None,
             "info": {
                 "args": {
-                    "repository": {"nargs": "?"},
+                    "repository": {"nargs": "?", "default": "published"},
                     "namespace": {},
                     "collection_name": {},
                     "version": {},
@@ -93,7 +96,7 @@ KIND_OPS = {
             },
             "sign": {
                 "args": {
-                    "repository": {"nargs": "?"},
+                    "repository": {"nargs": "?", "default": "published"},
                     "namespace": {},
                     "collection_name": {},
                     "version": {},
@@ -118,7 +121,7 @@ KIND_OPS = {
             "create": {
                 "args": {
                     "name": {},
-                    "group": {"nargs": "?"},
+                    "group": {"nargs": "?", "default": None},
                 }
             },
             "delete": {
@@ -150,7 +153,7 @@ KIND_OPS = {
             "readme": {
                 "args": {
                     "container": {},
-                    "readme": {"nargs": "?"},
+                    "readme": {"nargs": "?", "default": None},
                 }
             },
             "delete": {

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -49,10 +49,20 @@ KIND_OPS = {
                 "args": None,
             },
             "upload": {
+                "help": "Create and upload a new collection",
                 "args": {
-                    "namespace": {"nargs": "?"},
-                    "collection_name": {"nargs": "?"},
-                    "version": {"nargs": "?"},
+                    "namespace": {
+                        "help": "Collection namespace (optional, defaults to --username)",
+                        "nargs": "?",
+                    },
+                    "collection_name": {
+                        "help": "Collection name (optional, randomly generated)",
+                        "nargs": "?",
+                    },
+                    "version": {
+                        "help": "Version (optional, defaults to 1.0.0)",
+                        "nargs": "?",
+                    },
                 },
             },
             "move": {
@@ -200,18 +210,21 @@ KIND_OPS = {
                 }
             },
             "group": {
+                "help": "User group membership",
                 "subops": {
                     "add": {
+                        "help": "Add user to group",
                         "args": {
                             "username": {},
                             "groupname": {},
-                        }
+                        },
                     },
                     "remove": {
+                        "help": "Remove user from group",
                         "args": {
                             "username": {},
                             "groupname": {},
-                        }
+                        },
                     },
                 },
             },

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -351,6 +351,7 @@ def params_main(parser):
         "--username",
         action="store",
         default="admin",
+        dest="auth_username",
         type=str,
     )
     parser.add_argument(
@@ -358,6 +359,7 @@ def params_main(parser):
         "--password",
         action="store",
         default="admin",
+        dest="auth_password",
         type=str,
     )
     parser.add_argument(
@@ -412,8 +414,8 @@ def main():
     if args.auth_url and not args.token:
         creds = {
             "auth_url": args.auth_url,
-            "username": args.username,
-            "password": args.password,
+            "username": args.auth_username,
+            "password": args.auth_password,
         }
     elif args.token:
         creds = {
@@ -423,8 +425,8 @@ def main():
             creds["auth_url"] = args.auth_url
     else:
         creds = {
-            "username": args.username,
-            "password": args.password,
+            "username": args.auth_username,
+            "password": args.auth_password,
         }
     client = GalaxyClient(args.server, creds, https_verify=https_verify)
 


### PR DESCRIPTION
This is trying to do a similar thing to #30 , but reducing the scope to just moving all custom param parsing to argparse subparsers with no syntax changes and no DRYing up the actual commands yet.

The effect should be better help, more reliable failures with unexpected param counts, and ability to add named arguments easily.

(`help` description can be added to each `kind`, `op`, `subop` and `arg`, but it can be done gradually, mostly leaving out of this PR; It looks #30 has a lot more help text ready.)

(`args.function` is also out of scope, for now just having the subparser `dest=` to the original arg name (`kind`, `operation`, `subop`))
(`args.rest` is gone now)

Renaming `args.username` & `args.password` to `args.auth_username` and `args.auth_password`, to prevent clashes with the `username` and `password` positional arguments for `user create`. (`version` would also conflict but main uses `action="version"`, not `action="store"`)

Also adding `--debug` and `--version` params, and `admin` default values for `username` and `password`.