### PR TITLE
Keep python3.8 compatibility - argparse.BooleanOptionalAction is 3.9+; fix superuser creation

### DIFF
--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -208,8 +208,8 @@ KIND_OPS = {
                     "--email": {},
                     "--first_name": {},
                     "--is_superuser": {
+                        "action": "store_true",
                         "default": False,
-                        "action": argparse.BooleanOptionalAction,
                     },
                     "--last_name": {},
                 }

--- a/galaxykit/users.py
+++ b/galaxykit/users.py
@@ -23,7 +23,9 @@ def get_or_create_user(
     user_url = f"_ui/v1/users?username={username}"
     user_resp = client.get(user_url)
     if user_resp["meta"]["count"] == 0:
-        return True, create_user(client, username, password, group, fname, lname, email)
+        return True, create_user(
+            client, username, password, group, fname, lname, email, superuser
+        )
 
     return False, user_resp["data"][0]
 


### PR DESCRIPTION
Introduced in #49, `argparse.BooleanOptionalAction` is python 3.9+ only.
Changing to keep python 3.8 compatiblity.

Fixes

    galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin collection list

    Traceback (most recent call last):
      File "/home/runner/.local/bin/galaxykit", line 5, in <module>
        from galaxykit.command import main
      File "/home/runner/.local/lib/python3.8/site-packages/galaxykit/command.py", line 212, in <module>
        "action": argparse.BooleanOptionalAction,
    AttributeError: module 'argparse' has no attribute 'BooleanOptionalAction'
    Error: Process completed with exit code 1.

(https://github.com/ansible/ansible-hub-ui/pull/2233)

---

Also fixing an issue where `get_or_create_user` is not passing the superuser flag to `create_user`.