### PR TITLE
Refresh JWT tokens on expiration

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -131,7 +131,6 @@ class GalaxyClient:
                     container_registry,
                     tls_verify=container_tls_verify,
                 )
-    
     def _refresh_jwt_token(self):
         if not self.original_token:
             self.original_token = self.token
@@ -173,7 +172,7 @@ class GalaxyClient:
             method, url, headers=headers, verify=self.https_verify, *args, **kwargs
         )
 
-        if 'Invalid JWT token' in resp.text and 'claim expired' in resp.text:
+        if "Invalid JWT token" in resp.text and "claim expired" in resp.text:
             self._refresh_jwt_token()
             self._update_auth_headers()
             resp = requests.request(

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -1,6 +1,7 @@
 """
 client.py contains the wrapping interface for all the other modules (aside from cli.py)
 """
+import logging
 import platform
 import sys
 from urllib.parse import urlparse, urljoin
@@ -17,6 +18,9 @@ from . import namespaces
 from . import collections
 from . import __version__ as VERSION
 from .utils import GalaxyClientError
+
+
+logger = logging.getLogger(__name__)
 
 
 def user_agent():
@@ -132,7 +136,7 @@ class GalaxyClient:
         if not self.original_token:
             self.original_token = self.token
         else:
-            print("!!!! REFRESHING JWT TOKEN !!!!")
+            logger.warning("Refreshing JWT Token and retrying request")
 
         payload = "grant_type=refresh_token&client_id=%s&refresh_token=%s" % (
             "cloud-services",

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -131,6 +131,7 @@ class GalaxyClient:
                     container_registry,
                     tls_verify=container_tls_verify,
                 )
+
     def _refresh_jwt_token(self):
         if not self.original_token:
             self.original_token = self.token


### PR DESCRIPTION
If a request results in an expired JWT token error, try to refresh it and try again