### PR TITLE
Bring back pre-RBAC permission utilities

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -95,7 +95,9 @@ class GalaxyClient:
                 jdata = self._http("post", self.auth_url, headers=headers, data=ds)
                 self.token_type = "Bearer"
                 if "access_token" not in jdata:
-                    raise GalaxyClientError(f"`access_token` not found in JWT response.")
+                    raise GalaxyClientError(
+                        f"`access_token` not found in JWT response."
+                    )
                 self.token = jdata["access_token"]
 
             elif self.token and self.auth_url:
@@ -103,7 +105,9 @@ class GalaxyClient:
 
             elif self.token is None:
                 auth_url = urljoin(self.galaxy_root, "v3/auth/token/")
-                resp = self._http("post", auth_url, auth=(self.username, self.password), headers=None)
+                resp = self._http(
+                    "post", auth_url, auth=(self.username, self.password), headers=None
+                )
                 try:
                     self.token = resp.get("token")
                 except JSONDecodeError:
@@ -159,7 +163,7 @@ class GalaxyClient:
                 "Authorization": f"{self.token_type} {self.token}",
             }
         )
-    
+
     def _get_server_version(self):
         return self._http("get", self.galaxy_root)["galaxy_ng_version"]
 
@@ -187,7 +191,9 @@ class GalaxyClient:
             try:
                 json = resp.json()
             except JSONDecodeError as exc:
-                logging.error(f"Cannot parse expected JSON response ({url}): {resp.text}")
+                logging.error(
+                    f"Cannot parse expected JSON response ({url}): {resp.text}"
+                )
                 raise ValueError("Failed to parse JSON response from API") from exc
             if "errors" in json:
                 raise GalaxyClientError(*json["errors"])
@@ -357,7 +363,7 @@ class GalaxyClient:
         if self._rbac_enabled is None:
             self._rbac_enabled = self._is_rbac_available()
         return self._rbac_enabled
-    
+
     @property
     def server_version(self):
         if self._server_version is None:

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -45,6 +45,7 @@ class GalaxyClient:
 
     headers = None
     galaxy_root = ""
+    auth_url = None
     original_token = None
     token = ""
     token_type = None
@@ -52,6 +53,7 @@ class GalaxyClient:
     username = ""
     password = ""
     _rbac_enabled = None
+    _server_version = None
 
     def __init__(
         self,
@@ -90,16 +92,10 @@ class GalaxyClient:
                     "password": self.password,
                     "grant_type": "password",
                 }
-                rr = requests.post(self.auth_url, headers=headers, data=ds)
-                if rr.status_code != 200:
-                    raise Exception(rr.text)
+                jdata = self._http("post", self.auth_url, headers=headers, data=ds)
                 self.token_type = "Bearer"
-                try:
-                    jdata = rr.json()
-                except Exception as e:
-                    raise Exception(rr.text)
                 if "access_token" not in jdata:
-                    raise Exception(rr.text)
+                    raise GalaxyClientError(f"`access_token` not found in JWT response.")
                 self.token = jdata["access_token"]
 
             elif self.token and self.auth_url:
@@ -107,11 +103,9 @@ class GalaxyClient:
 
             elif self.token is None:
                 auth_url = urljoin(self.galaxy_root, "v3/auth/token/")
-                resp = requests.post(
-                    auth_url, auth=(self.username, self.password), verify=False
-                )
+                resp = self._http("post", auth_url, auth=(self.username, self.password), headers=None)
                 try:
-                    self.token = resp.json().get("token")
+                    self.token = resp.get("token")
                 except JSONDecodeError:
                     print(f"Failed to fetch token: {resp.text}", file=sys.stderr)
 
@@ -148,13 +142,13 @@ class GalaxyClient:
             "User-Agent": user_agent(),
             "Content-Type": "application/x-www-form-urlencoded",
         }
-        resp = requests.post(
+        json = self._http(
+            "post",
             self.auth_url,
             data=payload,
             verify=self.https_verify,
             headers=headers,
         )
-        json = resp.json()
         self.token = json["access_token"]
         self.token_type = "Bearer"
 
@@ -165,10 +159,12 @@ class GalaxyClient:
                 "Authorization": f"{self.token_type} {self.token}",
             }
         )
+    
+    def _get_server_version(self):
+        return self._http("get", self.galaxy_root)["galaxy_ng_version"]
 
     def _is_rbac_available(self):
-        resp = requests.get(self.galaxy_root, headers=self.headers)
-        galaxy_ng_version = resp.json()["galaxy_ng_version"]
+        galaxy_ng_version = self.server_version
         return parse_version(galaxy_ng_version) >= parse_version("4.6.0dev")
 
     def _http(self, method, path, *args, **kwargs):
@@ -191,6 +187,7 @@ class GalaxyClient:
             try:
                 json = resp.json()
             except JSONDecodeError as exc:
+                logging.error(f"Cannot parse expected JSON response ({url}): {resp.text}")
                 raise ValueError("Failed to parse JSON response from API") from exc
             if "errors" in json:
                 raise GalaxyClientError(*json["errors"])
@@ -285,6 +282,12 @@ class GalaxyClient:
         """
         return groups.delete_group(self, group_name)
 
+    def set_permissions(self, group_name, permissions):
+        """
+        Assigns the given permissions to the group
+        """
+        return groups.set_permissions(self, group_name, permissions)
+
     def get_container_readme(self, container):
         return containers.get_readme(self, container)
 
@@ -354,3 +357,9 @@ class GalaxyClient:
         if self._rbac_enabled is None:
             self._rbac_enabled = self._is_rbac_available()
         return self._rbac_enabled
+    
+    @property
+    def server_version(self):
+        if self._server_version is None:
+            self._server_version = self._get_server_version()
+        return self._server_version

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -1,6 +1,7 @@
 import argparse
-import sys
 import json
+import logging
+import sys
 from pprint import pprint
 
 from .client import GalaxyClient
@@ -20,6 +21,9 @@ EXIT_OK = 0
 EXIT_UNKNOWN_ERROR = 1
 EXIT_NOT_FOUND = 2
 EXIT_DUPLICATE = 4
+EXIT_SERVER_VERSION = 8
+
+logger = logging.getLogger(__name__)
 
 
 def format_list(data, identifier):
@@ -37,7 +41,7 @@ def format_list(data, identifier):
 def report_error(resp):
     if "errors" in resp:
         for error in resp["errors"]:
-            print(
+            logger.error(
                 f"API Failure: HTTP {error['status']} {error['code']}; {error['title']} ({error['detail']})"
             )
 
@@ -266,6 +270,29 @@ KIND_OPS = {
                     "name": {},
                 },
             },
+            # For galaxy_ng <4.6
+            "permission": {
+                "subops": {
+                    "list": {
+                        "args": {
+                            "groupname": {},
+                        },
+                    },
+                    "add": {
+                        "args": {
+                            "groupname": {},
+                            "perm": {},
+                        },
+                    },
+                    "remove": {
+                        "args": {
+                            "groupname": {},
+                            "perm": {},
+                        },
+                    },
+                },
+            },
+            # for galaxy_ng >=4.6
             "role": {
                 "subops": {
                     "list": {
@@ -602,39 +629,62 @@ def main():
                     resp = groups.remove_role(client, args.groupname, args.rolename)
 
         elif args.kind == "role":
-            if args.operation == "list":
-                resp = roles.get_role_list(client)
-                print(format_list(resp["results"], "name"))
-            elif args.operation == "create":
-                permissions = args.permissions.split(",") if args.permissions else []
-                try:
-                    resp = roles.create_role(
-                        client, args.name, args.description, permissions
-                    )
-                except ValueError as e:
-                    if not args.ignore:
-                        print(e)
-                        sys.exit(EXIT_NOT_FOUND)
-            elif args.operation == "delete":
-                try:
-                    resp = roles.delete_role(client, args.name)
-                except ValueError as e:
-                    if not args.ignore:
-                        print(e)
-                        sys.exit(EXIT_NOT_FOUND)
+            if client.rbac_enabled():
+                if args.operation == "list":
+                    resp = roles.get_role_list(client)
+                    print(format_list(resp["results"], "name"))
+                elif args.operation == "create":
+                    permissions = args.permissions.split(",") if args.permissions else []
+                    try:
+                        resp = roles.create_role(
+                            client, args.name, args.description, permissions
+                        )
+                    except ValueError as e:
+                        if not args.ignore:
+                            print(e)
+                            sys.exit(EXIT_NOT_FOUND)
+                elif args.operation == "delete":
+                    try:
+                        resp = roles.delete_role(client, args.name)
+                    except ValueError as e:
+                        if not args.ignore:
+                            print(e)
+                            sys.exit(EXIT_NOT_FOUND)
+            else:
+                logger.error(f"The `{args.kind}` subcommand is not supported for server versions below 4.6")
+                sys.exit(EXIT_SERVER_VERSION)
 
-            elif args.operation == "perm":
-                if args.subop == "list":
+        # The `perm` sub-command acts on group objects in versions 4.5 and below
+        # and on role objects in versions 4.6 and above.
+        elif args.operation == "perm":
+            if args.subop == "list":
+                if client.rbac_enabled():
                     resp = roles.get_permissions(client, args.rolename)
                     print(resp)
-                elif args.subop == "add":
+                else:
+                    resp = groups.get_permissions(client, groupname)
+                    print(format_list(resp["data"], "permission"))
+            elif args.subop == "add":
+                if client.rbac_enabled():
                     resp = roles.set_permissions(
                         client, args.rolename, add_permissions=[args.perm]
                     )
-                elif args.subop == "remove":
+                else:
+                    groupname, perm = args.groupname, args.perm
+                    perms = [
+                        p["permission"]
+                        for p in groups.get_permissions(client, groupname)["data"]
+                    ]
+                    perms = list(set(perms) | set([perm]))
+                    resp = groups.set_permissions(client, groupname, perms)
+            elif args.subop == "remove":
+                if client.rbac_enabled():
                     resp = roles.set_permissions(
                         client, args.rolename, remove_permissions=[args.perm]
                     )
+                else:
+                    groupname, perm = args.groupname, args.perm
+                    resp = groups.delete_permission(client, groupname, perm)
 
         elif args.kind == "namespace":
             if args.operation == "get":
@@ -689,7 +739,7 @@ def main():
                     resp = containers.delete_container(client, name)
                 except ValueError as e:
                     if not args.ignore:
-                        print(e)
+                        logger.error(e)
                         sys.exit(EXIT_NOT_FOUND)
 
             elif args.operation == "create":
@@ -704,7 +754,7 @@ def main():
                     )
                 except ValueError as e:
                     if not args.ignore:
-                        print(e)
+                        logger.error(e)
                         sys.exit(EXIT_NOT_FOUND)
 
         elif args.kind == "container-image":
@@ -714,7 +764,7 @@ def main():
                     resp = container_images.delete_container(client, container, image)
                 except ValueError as e:
                     if not args.ignore:
-                        print(e)
+                        logger.error(e)
                         sys.exit(EXIT_NOT_FOUND)
 
         elif args.kind == "registry":
@@ -724,7 +774,7 @@ def main():
                     resp = registries.delete_registry(client, name)
                 except ValueError as e:
                     if not args.ignore:
-                        print(e)
+                        logger.error(e)
                         sys.exit(EXIT_NOT_FOUND)
             elif args.operation == "create":
                 name, url = args.name, args.url
@@ -732,7 +782,7 @@ def main():
                     resp = registries.create_registry(client, name, url)
                 except ValueError as e:
                     if not args.ignore:
-                        print(e)
+                        logger.error(e)
                         sys.exit(EXIT_NOT_FOUND)
 
         elif args.kind == "collection":
@@ -779,7 +829,7 @@ def main():
                     )
                 except ValueError as e:
                     if not args.ignore:
-                        print(e)
+                        logger.error(e)
                         sys.exit(EXIT_NOT_FOUND)
             elif args.operation == "download":
                 raise NotImplementedError

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -634,7 +634,9 @@ def main():
                     resp = roles.get_role_list(client)
                     print(format_list(resp["results"], "name"))
                 elif args.operation == "create":
-                    permissions = args.permissions.split(",") if args.permissions else []
+                    permissions = (
+                        args.permissions.split(",") if args.permissions else []
+                    )
                     try:
                         resp = roles.create_role(
                             client, args.name, args.description, permissions
@@ -651,7 +653,9 @@ def main():
                             print(e)
                             sys.exit(EXIT_NOT_FOUND)
             else:
-                logger.error(f"The `{args.kind}` subcommand is not supported for server versions below 4.6")
+                logger.error(
+                    f"The `{args.kind}` subcommand is not supported for server versions below 4.6"
+                )
                 sys.exit(EXIT_SERVER_VERSION)
 
         # The `perm` sub-command acts on group objects in versions 4.5 and below

--- a/galaxykit/groups.py
+++ b/galaxykit/groups.py
@@ -153,7 +153,7 @@ def add_permissions(client, group_name, permissions):
         req_payload = {
             "permission": perm,
         }
-        client.post( permissions_url, req_payload)
+        client.post(permissions_url, req_payload)
 
 
 def delete_permission(client, group_name, permission):

--- a/galaxykit/groups.py
+++ b/galaxykit/groups.py
@@ -1,3 +1,6 @@
+import json
+from pprint import pprint
+
 from . import roles
 
 
@@ -104,3 +107,64 @@ def add_role_to_group(client, role_name, group_id):
     role_to_group_url = f"pulp/api/v3/groups/{group_id}/roles/"
     body = {"role": role_name, "content_object": None}
     return client.post(role_to_group_url, body)
+
+
+# Legacy role operations
+
+
+def get_permissions(client, group_name):
+    group_id = get_group(client, group_name)["id"]
+    permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
+    return client.get(permissions_url)
+
+
+def set_permissions(client, group_name, permissions):
+    """
+    Assigns the given permissions to the group.
+    `permissions` must be a list of strings, each one recognized as a permission by the backend. See
+    them listed at the link below:
+    https://github.com/ansible/galaxy_ng/blob/ca503375077a225a5fb215e6fb2c6ae47e09cfd7/galaxy_ng/app/api/ui/serializers/user.py#L122
+    Container permissions are in another file:
+    https://github.com/ansible/galaxy_ng/blob/009385fb3a1a34d1df9ff369e2e15c3fa27869b3/galaxy_ng/app/access_control/statements/pulp_container.py#L139
+
+    The permissions are the ones that match the "namespace.permission-name" format.
+
+    """
+    group_id = get_group(client, group_name)["id"]
+    permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
+    for perm in permissions:
+        payload = {"permission": perm}
+        client.post(permissions_url, payload)
+        # TODO: Check the results of each and aggregate for a return value
+
+
+def add_permissions(client, group_name, permissions):
+    """
+    `permissions` must be a list of strings, each one recognized as a permission by the backend. See
+    them listed at the link below:
+    https://github.com/ansible/galaxy_ng/blob/ca503375077a225a5fb215e6fb2c6ae47e09cfd7/galaxy_ng/app/api/ui/serializers/user.py#L122
+
+    The permissions are the ones that match the "namespace.permission-name" format.
+
+    """
+    group_id = get_group(client, group_name)["id"]
+    permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
+    for perm in permissions:
+        req_payload = {
+            "permission": perm,
+        }
+        client.post( permissions_url, req_payload)
+
+
+def delete_permission(client, group_name, permission):
+    """
+    Removes a permission from a group.
+    """
+    group_id = get_group(client, group_name)["id"]
+    permissions_url = f"_ui/v1/groups/{group_id}/model-permissions/"
+    resp = client.get(permissions_url)
+    for perm in resp["data"]:
+        if perm["permission"] == permission:
+            perm_id = perm["id"]
+            perm_url = f"_ui/v1/groups/{group_id}/model-permissions/{perm_id}/"
+            client.delete(perm_url, parse_json=False)


### PR DESCRIPTION
Restore permission utilities for pre 4.6 versions of galaxy_ng. Expand server version checking.

- Push all HTTP requests through the _http wrapper (fixes TLS issues 🤞)
- Add default None for auth_url
- Restore set_permissions() helper
- Add a EXIT_SERVER_VERSION (8) exit code when unable to determine
- Use logging module for error logging instead of print