### PR TITLE
Improving how we manage container autentication tokens.

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -121,7 +121,6 @@ class GalaxyClient:
 
             self._update_auth_headers()
 
-    
     @property
     def container_client(self):
         """Only create a container client if its actually needed."""
@@ -143,7 +142,6 @@ class GalaxyClient:
                 tls_verify=self._container_tls_verify,
             )
         return self._container_client
-
 
     def _refresh_jwt_token(self):
         if not self.original_token:

--- a/galaxykit/containerutils.py
+++ b/galaxykit/containerutils.py
@@ -4,10 +4,12 @@ Holds all of the functions used by GalaxyClient to handle container operations.
 i.e. cli commands with podman, e.g. podman pull, podman image tag, etc.
 """
 
+from curses import use_default_colors
 from logging import getLogger
 from subprocess import run
 from subprocess import PIPE
 
+from .utils import GalaxyClientError
 
 logger = getLogger(__name__)
 
@@ -21,6 +23,8 @@ class ContainerClient:
     engine = ""
     registry = ""
     tls_verify = True
+
+    last_login_username = None
 
     def __init__(
         self,
@@ -37,11 +41,21 @@ class ContainerClient:
         self.engine = engine
         self.registry = registry
         self.tls_verify = tls_verify
+        self.auth = auth
 
-        if auth:  # we only need to auth if creds are supplied
+        if auth: # we only need to auth if creds are supplied
             self.login(*auth, fail_ok=True)
+    
+    def _check_login(self):
+        if self.auth:
+            username, _ = self.auth
+            if username != self.last_login_username:
+                self.login(self.username, self.password)
 
     def login(self, username, password, fail_ok=False):
+        if username == self.last_login_username:
+            return
+
         run_args = [
             self.engine,
             "login",
@@ -56,6 +70,10 @@ class ContainerClient:
         try:
             run_command(run_args)
             logger.debug(f"Logged in with user {username}")
+            self.username = username
+            self.password = password
+            # ! keep
+            ContainerClient.last_login_username = username
         except FileNotFoundError:
             if fail_ok:
                 logger.warn(f"Container engine '{self.engine}' not found.")
@@ -66,6 +84,7 @@ class ContainerClient:
         """
         pull an image from the configured default registry
         """
+        self._check_login()
         if self.engine == "podman" and not self.tls_verify:
             run_command(
                 [self.engine, "pull", self.registry + image_name, "--tls-verify=False"]
@@ -77,6 +96,7 @@ class ContainerClient:
         """
         Tags an image with the given tag (prepends the registry to the tag.)
         """
+        self._check_login()
         sep = "" if self.registry.endswith("/") else "/"
         full_tag = f"{self.registry}{sep}{image_tag}"
         run_args = [
@@ -92,6 +112,7 @@ class ContainerClient:
         """
         Pushes an image to the registry
         """
+        self._check_login()
         sep = "" if self.registry.endswith("/") else "/"
         full_tag = f"{self.registry}{sep}{image_tag}"
         run_args = [self.engine, "push", full_tag]
@@ -102,10 +123,14 @@ class ContainerClient:
         return run_command(run_args)
 
 
-def run_command(run_args):
-    logger.debug(f"Run command run_args: {' '.join(run_args)}")
+def run_command(run_args, retcode=0):
+    cmd_string = ' '.join(run_args)
+    logger.debug(f"Run command run_args: {cmd_string}")
     result = run(run_args, stderr=PIPE, stdout=PIPE)
     logger.debug(f"Run command stderr: {result.stderr.decode('utf-8')}")
     logger.debug(f"Run command stdout: {result.stdout.decode('utf-8')}")
     logger.debug(f"Run command return code: {result.returncode}")
+    if retcode is not None:
+        if result.returncode != retcode:
+            raise GalaxyClientError(f"Container engine command failed (retcode {result.returncode}): {cmd_string}")
     return result.returncode

--- a/galaxykit/containerutils.py
+++ b/galaxykit/containerutils.py
@@ -43,7 +43,7 @@ class ContainerClient:
         self.tls_verify = tls_verify
         self.auth = auth
 
-        if auth: # we only need to auth if creds are supplied
+        if auth:  # we only need to auth if creds are supplied
             self.login(*auth, fail_ok=True)
     
     def _check_login(self):
@@ -124,7 +124,7 @@ class ContainerClient:
 
 
 def run_command(run_args, retcode=0):
-    cmd_string = ' '.join(run_args)
+    cmd_string = " ".join(run_args)
     logger.debug(f"Run command run_args: {cmd_string}")
     result = run(run_args, stderr=PIPE, stdout=PIPE)
     logger.debug(f"Run command stderr: {result.stderr.decode('utf-8')}")
@@ -132,5 +132,7 @@ def run_command(run_args, retcode=0):
     logger.debug(f"Run command return code: {result.returncode}")
     if retcode is not None:
         if result.returncode != retcode:
-            raise GalaxyClientError(f"Container engine command failed (retcode {result.returncode}): {cmd_string}")
+            raise GalaxyClientError(
+                f"Container engine command failed (retcode {result.returncode}): {cmd_string}"
+            )
     return result.returncode

--- a/galaxykit/groups.py
+++ b/galaxykit/groups.py
@@ -2,6 +2,7 @@ import json
 from pprint import pprint
 
 from . import roles
+from .utils import GalaxyClientError
 
 
 def get_group(client, group_name):
@@ -24,11 +25,18 @@ def get_group_id(client, group_name):
         raise ValueError(f"No group '{group_name}' found.")
 
 
-def create_group(client, group_name):
+def create_group(client, group_name, exists_ok=True):
     """
     Creates a group
     """
-    return client.post("_ui/v1/groups/", {"name": group_name})
+    try:
+        return client.post("_ui/v1/groups/", {"name": group_name})
+    except GalaxyClientError as e:
+        if e.status_code == 409 and exists_ok:
+            # ok, already exists
+            pass
+        else:
+            raise
 
 
 def delete_group(client, group_name):

--- a/galaxykit/utils.py
+++ b/galaxykit/utils.py
@@ -2,7 +2,11 @@
 import logging
 import json
 import time
+from urllib import request
 from urllib.parse import urljoin
+
+import requests
+from simplejson.errors import JSONDecodeError
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +21,31 @@ class TaskFailed(Exception):
 
 
 class GalaxyClientError(Exception):
-    pass
+    response = None
+    json = None
+
+    @property
+    def status_code(self):
+        if self.response:
+            return self.response.status_code
+        else:
+            return None
+
+    def __init__(self, *args, **kwargs):
+        skip = 0
+        if args and isinstance(args[0], requests.Response):
+            self.response = args[0]
+            skip = 1
+        elif "response" in kwargs:
+            self.response = kwargs.pop("response")
+        if "json" in kwargs:
+            self.json = kwargs.pop("json")
+        elif self.response:
+            try:
+                self.json = self.response.json()
+            except JSONDecodeError:
+                pass
+        super().__init__(*args[skip:], **kwargs)
 
 
 def wait_for_task(api_client, task, timeout=300, raise_on_error=False):


### PR DESCRIPTION
- Only create the container client when its first used, so we don't create them unnecessarily.
- Allow GalaxyClientError to take a response or data object for context
- ContinerClient will remember which user is logged in, globally, and smartly re-login only when a container operation is performed by a different user than the previous.
- ContainerClient methods now check if a login is needed before doing their work.
- run_command checks the return code now
- create_group will allow 409 CONFLICT unless you pass exists_ok=False to tell it to fail if a group already exists.