### PR TITLE
Fix `'bool' object is not callable` when running galaxykit cli

### DIFF
--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -629,7 +629,7 @@ def main():
                     resp = groups.remove_role(client, args.groupname, args.rolename)
 
         elif args.kind == "role":
-            if client.rbac_enabled():
+            if client.rbac_enabled:
                 if args.operation == "list":
                     resp = roles.get_role_list(client)
                     print(format_list(resp["results"], "name"))
@@ -662,14 +662,14 @@ def main():
         # and on role objects in versions 4.6 and above.
         elif args.operation == "perm":
             if args.subop == "list":
-                if client.rbac_enabled():
+                if client.rbac_enabled:
                     resp = roles.get_permissions(client, args.rolename)
                     print(resp)
                 else:
                     resp = groups.get_permissions(client, groupname)
                     print(format_list(resp["data"], "permission"))
             elif args.subop == "add":
-                if client.rbac_enabled():
+                if client.rbac_enabled:
                     resp = roles.set_permissions(
                         client, args.rolename, add_permissions=[args.perm]
                     )
@@ -682,7 +682,7 @@ def main():
                     perms = list(set(perms) | set([perm]))
                     resp = groups.set_permissions(client, groupname, perms)
             elif args.subop == "remove":
-                if client.rbac_enabled():
+                if client.rbac_enabled:
                     resp = roles.set_permissions(
                         client, args.rolename, remove_permissions=[args.perm]
                     )


### PR DESCRIPTION
introduced in https://github.com/ansible/galaxykit/pull/71#discussion_r972006872,
`client.rbac_enabled` is a bool `@property`, thus not callable, removing parentheses

Fixes:

    Error: Galaxykit failed: Traceback (most recent call last):
    File "/home/runner/.local/bin/galaxykit", line 8, in <module>
        sys.exit(main())
    File "/home/runner/.local/lib/python3.8/site-packages/galaxykit/command.py", line 632, in main
        if client.rbac_enabled():
    TypeError: 'bool' object is not callable