### PR TITLE
Add --cookie auth support

### DIFF
--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -494,6 +494,11 @@ def params_main(parser):
         type=str,
     )
     parser.add_argument(
+        "--cookie",
+        action="store",
+        type=str,
+    )
+    parser.add_argument(
         "-a",
         "--auth-url",
         action="store",
@@ -548,6 +553,10 @@ def main():
         }
         if args.auth_url:
             creds["auth_url"] = args.auth_url
+    elif args.cookie:
+        creds = {
+            "cookie": args.cookie,
+        }
     else:
         creds = {
             "username": args.auth_username,


### PR DESCRIPTION
    galaxykit -s http://localhost:8002/api/automation-hub/ --cookie='...' collection list

(where ... is the value of the Cookie header pulled from a logged-in browser)

useful for connecting to local insights dev instances from cypress tests (https://github.com/ansible/ansible-hub-ui/pull/2740)
(and because I couldn't get `galaxykit  -s http://localhost:8002/api/automation-hub/ --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token' --token='...'` to work)