### PR TITLE
Add backwards compat for UI endpoints

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -55,7 +55,7 @@ class GalaxyClient:
     _rbac_enabled = None
     _server_version = None
     _container_client = None
-    _ui_endpoint_prefix = None
+    _ui_ee_endpoint_prefix = None
 
     def __init__(
         self,
@@ -382,11 +382,11 @@ class GalaxyClient:
         return self._server_version
 
     @property
-    def ui_endpoint_prefix(self):
-        if self._ui_endpoint_prefix is None:
+    def ui_ee_endpoint_prefix(self):
+        if self._ui_ee_endpoint_prefix is None:
             if parse_version(self.server_version) > parse_version("4.6.2"):
-                # the endpoints that used to be under _ui/v1/ moved to v3/plugin/ after 4.6.2
-                self._ui_endpoint_prefix = "v3/plugin/"
+                # the EE endpoints that used to be under _ui/v1/ moved to v3/plugin/ after 4.6.2
+                self._ui_ee_endpoint_prefix = "v3/plugin/"
             else:
-                self._ui_endpoint_prefix = "_ui/v1/"
-        return self._ui_endpoint_prefix
+                self._ui_ee_endpoint_prefix = "_ui/v1/"
+        return self._ui_ee_endpoint_prefix

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -384,8 +384,8 @@ class GalaxyClient:
     @property
     def ui_ee_endpoint_prefix(self):
         if self._ui_ee_endpoint_prefix is None:
-            if parse_version(self.server_version) > parse_version("4.6.2"):
-                # the EE endpoints that used to be under _ui/v1/ moved to v3/plugin/ after 4.6.2
+            if parse_version(self.server_version) >= parse_version("4.7.0dev"):
+                # the EE endpoints that used to be under _ui/v1/ moved to v3/plugin/ starting with 4.7.0dev
                 self._ui_ee_endpoint_prefix = "v3/plugin/"
             else:
                 self._ui_ee_endpoint_prefix = "_ui/v1/"

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -384,7 +384,7 @@ class GalaxyClient:
     @property
     def ui_endpoint_prefix(self):
         if self._ui_endpoint_prefix is None:
-            if parse_version(self.server_version) > parse_version("4.6.0dev"):
+            if parse_version(self.server_version) > parse_version("4.6.2"):
                 # the endpoints that used to be under _ui/v1/ moved to v3/plugin/ after 4.6.2
                 self._ui_endpoint_prefix = "v3/plugin/"
             else:

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -55,6 +55,7 @@ class GalaxyClient:
     _rbac_enabled = None
     _server_version = None
     _container_client = None
+    _ui_endpoint_prefix = None
 
     def __init__(
         self,
@@ -379,3 +380,13 @@ class GalaxyClient:
         if self._server_version is None:
             self._server_version = self._get_server_version()
         return self._server_version
+
+    @property
+    def ui_endpoint_prefix(self):
+        if self._ui_endpoint_prefix is None:
+            if parse_version(self.server_version) > parse_version("4.6.0dev"):
+                # the endpoints that used to be under _ui/v1/ moved to v3/plugin/ after 4.6.2
+                self._ui_endpoint_prefix = "v3/plugin/"
+            else:
+                self._ui_endpoint_prefix = "_ui/v1/"
+        return self._ui_endpoint_prefix

--- a/galaxykit/container_images.py
+++ b/galaxykit/container_images.py
@@ -5,7 +5,7 @@ def delete_container(client, container, image):
     """
     Delete container image
     """
-    delete_url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/images/{image}/"
+    delete_url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{container}/_content/images/{image}/"
 
     return client.delete(delete_url, parse_json=False)
 
@@ -14,7 +14,7 @@ def get_container_images(client, container):
     """
     Gets container images
     """
-    get_url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/images/"
+    get_url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{container}/_content/images/"
     return client.get(get_url)
 
 
@@ -22,7 +22,7 @@ def get_container_history(client, container):
     """
     Gets container history
     """
-    get_url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/history/"
+    get_url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{container}/_content/history/"
     return client.get(get_url)
 
 
@@ -30,7 +30,7 @@ def get_containers(client):
     """
     Gets containers
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/"
     return client.get(url)
 
 
@@ -38,7 +38,7 @@ def get_container(client, name):
     """
     Gets a container
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{name}/"
     return client.get(url)
 
 
@@ -46,7 +46,7 @@ def get_container_readme(client, name):
     """
     Gets container's readme
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/_content/readme/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{name}/_content/readme/"
     return client.get(url)
 
 
@@ -54,5 +54,5 @@ def put_container_readme(client, name, data):
     """
     Updates container's readme
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/_content/readme/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{name}/_content/readme/"
     return client.put(url, body=data)

--- a/galaxykit/container_images.py
+++ b/galaxykit/container_images.py
@@ -5,7 +5,12 @@ def delete_container(client, container, image):
     """
     Delete container image
     """
-    delete_url = f"v3/plugin/execution-environments/repositories/{container}/_content/images/{image}/"
+    if version.parse(client.server_version) > version.parse("4.5.*"):
+
+        delete_url = f"v3/plugin/execution-environments/repositories/{container}/_content/images/{image}/"
+    else:
+        delete_url = f"_ui/v1/execution-environments/repositories/{container}/_content/images/{image}/"
+
     return client.delete(delete_url, parse_json=False)
 
 

--- a/galaxykit/container_images.py
+++ b/galaxykit/container_images.py
@@ -5,11 +5,7 @@ def delete_container(client, container, image):
     """
     Delete container image
     """
-    if version.parse(client.server_version) > version.parse("4.5.*"):
-
-        delete_url = f"v3/plugin/execution-environments/repositories/{container}/_content/images/{image}/"
-    else:
-        delete_url = f"_ui/v1/execution-environments/repositories/{container}/_content/images/{image}/"
+    delete_url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/images/{image}/"
 
     return client.delete(delete_url, parse_json=False)
 
@@ -18,7 +14,7 @@ def get_container_images(client, container):
     """
     Gets container images
     """
-    get_url = f"_ui/v1/execution-environments/repositories/{container}/_content/images/"
+    get_url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/images/"
     return client.get(get_url)
 
 
@@ -26,9 +22,7 @@ def get_container_history(client, container):
     """
     Gets container history
     """
-    get_url = (
-        f"_ui/v1/execution-environments/repositories/{container}/_content/history/"
-    )
+    get_url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/history/"
     return client.get(get_url)
 
 
@@ -36,7 +30,7 @@ def get_containers(client):
     """
     Gets containers
     """
-    url = "_ui/v1/execution-environments/repositories/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/"
     return client.get(url)
 
 
@@ -44,7 +38,7 @@ def get_container(client, name):
     """
     Gets a container
     """
-    url = f"_ui/v1/execution-environments/repositories/{name}/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/"
     return client.get(url)
 
 
@@ -52,7 +46,7 @@ def get_container_readme(client, name):
     """
     Gets container's readme
     """
-    url = f"_ui/v1/execution-environments/repositories/{name}/_content/readme/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/_content/readme/"
     return client.get(url)
 
 
@@ -60,5 +54,5 @@ def put_container_readme(client, name, data):
     """
     Updates container's readme
     """
-    url = f"_ui/v1/execution-environments/repositories/{name}/_content/readme/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/_content/readme/"
     return client.put(url, body=data)

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -1,4 +1,5 @@
 from pprint import pprint
+from packaging import version
 from . import registries
 
 
@@ -6,11 +7,7 @@ def get_readme(client, container):
     """
     Returns a json response containing the readme
     """
-    if version.parse(client.server_version) > version.parse("4.5.*"):
-
-        url = f"v3/plugin/execution-environments/repositories/{container}/_content/readme/"
-    else:
-        url = f"_ui/v1/execution-environments/repositories/{container}/_content/readme/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/readme/"
     return client.get(url)
 
 
@@ -18,11 +15,7 @@ def set_readme(client, container, readme):
     """
     Accepts a string and sets the container readme to that string.
     """
-    if version.parse(client.server_version) > version.parse("4.5.*"):
-
-        url = f"v3/plugin/execution-environments/repositories/{container}/_content/readme/"
-    else:
-        url = f"_ui/v1/execution-environments/repositories/{container}/_content/readme/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/readme/"
     resp = get_readme(client, container)
     resp["text"] = readme
     return client.put(url, resp)
@@ -32,7 +25,9 @@ def delete_container(client, name):
     """
     Delete container
     """
-    delete_url = f"v3/plugin/execution-environments/repositories/{name}/"
+    delete_url = (
+        f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/"
+    )
     return client.delete(delete_url, parse_json=False)
 
 
@@ -40,7 +35,7 @@ def create_container(client, name, upstream_name, registry):
     """
     Create container
     """
-    create_url = f"_ui/v1/execution-environments/remotes/"
+    create_url = f"{client.ui_endpoint_prefix}execution-environments/remotes/"
     registry_id = registries.get_registry_pk(client, registry)
     data = {
         "name": name,
@@ -56,7 +51,7 @@ def add_owner_to_ee(client, ee_name, group_name, object_roles):
     """
     Add owner to Execution Environment
     """
-    url = f"_ui/v1/execution-environments/namespaces/{ee_name}/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/namespaces/{ee_name}/"
     existing_groups = client.get(url)["groups"]
     existing_groups.append({"name": group_name, "object_roles": object_roles})
     data = {"groups": existing_groups}
@@ -67,5 +62,5 @@ def inspect_container_namespace(client, ee_name):
     """
     Inspect a container namepsace
     """
-    url = f"_ui/v1/execution-environments/namespaces/{ee_name}/"
+    url = f"{client.ui_endpoint_prefix}execution-environments/namespaces/{ee_name}/"
     return client.get(url)

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -6,7 +6,11 @@ def get_readme(client, container):
     """
     Returns a json response containing the readme
     """
-    url = f"v3/plugin/execution-environments/repositories/{container}/_content/readme/"
+    if version.parse(client.server_version) > version.parse("4.5.*"):
+
+        url = f"v3/plugin/execution-environments/repositories/{container}/_content/readme/"
+    else:
+        url = f"_ui/v1/execution-environments/repositories/{container}/_content/readme/"
     return client.get(url)
 
 
@@ -14,7 +18,11 @@ def set_readme(client, container, readme):
     """
     Accepts a string and sets the container readme to that string.
     """
-    url = f"v3/plugin/execution-environments/repositories/{container}/_content/readme/"
+    if version.parse(client.server_version) > version.parse("4.5.*"):
+
+        url = f"v3/plugin/execution-environments/repositories/{container}/_content/readme/"
+    else:
+        url = f"_ui/v1/execution-environments/repositories/{container}/_content/readme/"
     resp = get_readme(client, container)
     resp["text"] = readme
     return client.put(url, resp)

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -6,7 +6,7 @@ def get_readme(client, container):
     """
     Returns a json response containing the readme
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/readme/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{container}/_content/readme/"
     return client.get(url)
 
 
@@ -14,7 +14,7 @@ def set_readme(client, container, readme):
     """
     Accepts a string and sets the container readme to that string.
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/repositories/{container}/_content/readme/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{container}/_content/readme/"
     resp = get_readme(client, container)
     resp["text"] = readme
     return client.put(url, resp)
@@ -25,7 +25,7 @@ def delete_container(client, name):
     Delete container
     """
     delete_url = (
-        f"{client.ui_endpoint_prefix}execution-environments/repositories/{name}/"
+        f"{client.ui_ee_endpoint_prefix}execution-environments/repositories/{name}/"
     )
     return client.delete(delete_url, parse_json=False)
 
@@ -34,7 +34,7 @@ def create_container(client, name, upstream_name, registry):
     """
     Create container
     """
-    create_url = f"{client.ui_endpoint_prefix}execution-environments/remotes/"
+    create_url = f"{client.ui_ee_endpoint_prefix}execution-environments/remotes/"
     registry_id = registries.get_registry_pk(client, registry)
     data = {
         "name": name,
@@ -50,7 +50,7 @@ def add_owner_to_ee(client, ee_name, group_name, object_roles):
     """
     Add owner to Execution Environment
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/namespaces/{ee_name}/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/namespaces/{ee_name}/"
     existing_groups = client.get(url)["groups"]
     existing_groups.append({"name": group_name, "object_roles": object_roles})
     data = {"groups": existing_groups}
@@ -61,5 +61,5 @@ def inspect_container_namespace(client, ee_name):
     """
     Inspect a container namepsace
     """
-    url = f"{client.ui_endpoint_prefix}execution-environments/namespaces/{ee_name}/"
+    url = f"{client.ui_ee_endpoint_prefix}execution-environments/namespaces/{ee_name}/"
     return client.get(url)

--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -1,5 +1,4 @@
 from pprint import pprint
-from packaging import version
 from . import registries
 
 

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -8,7 +8,10 @@ def get_registry_pk(client, name):
     user_url = f"_ui/v1/execution-environments/registries/?name={name}"
     resp = client.get(user_url)
     if resp["data"]:
-        return resp["data"][0]["id"]
+        if version.parse(client.server_version) > version.parse("4.5.*"):
+            return resp["data"][0]["id"]
+        else:
+            return resp["data"][0]["pk"]
     else:
         raise ValueError(f"No registry '{name}' found.")
 

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -9,7 +9,7 @@ def get_registry_pk(client, name):
     user_url = f"_ui/v1/execution-environments/registries/?name={name}"
     resp = client.get(user_url)
     if resp["data"]:
-        if parse_version(client.server_version) > parse_version("4.6.2"):
+        if parse_version(client.server_version) >= parse_version("4.7.0dev"):
             return resp["data"][0]["id"]
         else:
             return resp["data"][0]["pk"]

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -1,4 +1,5 @@
 from pprint import pprint
+from pkg_resources import parse_version
 
 
 def get_registry_pk(client, name):
@@ -8,7 +9,7 @@ def get_registry_pk(client, name):
     user_url = f"_ui/v1/execution-environments/registries/?name={name}"
     resp = client.get(user_url)
     if resp["data"]:
-        if version.parse(client.server_version) > version.parse("4.5.*"):
+        if parse_version(client.server_version) > parse_version("4.6.2"):
             return resp["data"][0]["id"]
         else:
             return resp["data"][0]["pk"]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages={"galaxykit"},
     url="https://github.com/hendersonreed/galaxykit/",
     version=VERSION,
-    install_requires=["requests", "simplejson", "orionutils", "pyyaml"],
+    install_requires=["requests", "simplejson", "orionutils", "pyyaml", "packaging"],
     extra_requires={"dev": ["pre-commit"]},
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages={"galaxykit"},
     url="https://github.com/hendersonreed/galaxykit/",
     version=VERSION,
-    install_requires=["requests", "simplejson", "orionutils", "pyyaml", "packaging"],
+    install_requires=["requests", "simplejson", "orionutils", "pyyaml"],
     extra_requires={"dev": ["pre-commit"]},
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Enabling galaxykit to automatically work out which endpoints it should use for what used to be `_ui/v1/` will fix a large number of QE pipelines that rely on galaxykit's main branch.

I've done this by putting all the decision logic in a property under the client class (boy, it's getting to be a big one huh?) and interpolating that property into the relevant URLs.

Testing isn't done yet, hence why I've got this PR in `draft` state.

~~We do need to bump the version of the dev env before we can fix those QE pipelines, since at the moment galaxykit can't distinguish between the current development env (which erroneously reports its version as 4.6.2 and requires the new endpoints) and the released galaxy_ng component in AAP 2.3 (which is the "real" 4.6.2 and uses the old endpoints).~~

ignore the above - my local dev environment was `stable-4.6`, not `master` like I thought.