### PR TITLE
containers.create_container: fix URL

### DIFF
--- a/galaxykit/containers.py
+++ b/galaxykit/containers.py
@@ -34,7 +34,7 @@ def create_container(client, name, upstream_name, registry):
     """
     Create container
     """
-    create_url = f"{client.ui_ee_endpoint_prefix}execution-environments/remotes/"
+    create_url = f"_ui/v1/execution-environments/remotes/"
     registry_id = registries.get_registry_pk(client, registry)
     data = {
         "name": name,


### PR DESCRIPTION
in #80 this was changed to a v3 api url, but that one is only for EE repositories, not EE remotes

changing back

fixes:

    $ galaxykit container create foo bar baz
    Galaxykit failed: ERROR:root:Cannot parse expected JSON response (http://localhost:8002/api/galaxy/v3/plugin/execution-environments/remotes/)

Cc @hendersonreed @jerabekjiri 