### PR TITLE
Upload test collection with tags

### DIFF
--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -35,7 +35,12 @@ def get_all_collections(client):
 
 
 def upload_test_collection(
-    client, namespace=None, collection_name=None, version="1.0.0", path="staging", tags=["tools"]
+    client,
+    namespace=None,
+    collection_name=None,
+    version="1.0.0",
+    path="staging",
+    tags=["tools"],
 ):
     """
     Uploads a test collection generated with orionutils

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -35,7 +35,7 @@ def get_all_collections(client):
 
 
 def upload_test_collection(
-    client, namespace=None, collection_name=None, version="1.0.0", path="staging"
+    client, namespace=None, collection_name=None, version="1.0.0", path="staging", tags=["tools"]
 ):
     """
     Uploads a test collection generated with orionutils
@@ -47,7 +47,7 @@ def upload_test_collection(
     if collection_name is not None:
         config["name"] = collection_name
     # cloud importer config requires at least one tag
-    config["tags"] = ["tools"]
+    config["tags"] = tags
     artifact = build_collection("skeleton", config=config)
     upload_resp_url = upload_artifact(config, client, artifact, path=path)["task"]
 

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -96,7 +96,7 @@ KIND_OPS = {
                         "help": "Tags for collection.",
                         "nargs": "*",
                         "default": None,
-                    }
+                    },
                 },
             },
             "move": {
@@ -1013,7 +1013,7 @@ def main():
                     args.collection_name,
                     args.version or "1.0.0",
                     args.path or "staging",
-                    args.tags or ["tools"]
+                    args.tags or ["tools"],
                 )
                 resp = namespaces.create_namespace(client, namespace, None)
                 artifact = collections.upload_test_collection(

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -92,6 +92,11 @@ KIND_OPS = {
                         "nargs": "?",
                         "default": "staging",
                     },
+                    "--tags": {
+                        "help": "Tags for collection.",
+                        "nargs": "*",
+                        "default": None,
+                    }
                 },
             },
             "move": {
@@ -1003,11 +1008,12 @@ def main():
             if args.operation == "list":
                 print(json.dumps(collections.get_collection_list(client)))
             elif args.operation == "upload":
-                namespace, collection_name, version, path = (
+                namespace, collection_name, version, path, tags = (
                     args.namespace or client.username,
                     args.collection_name,
                     args.version or "1.0.0",
                     args.path or "staging",
+                    args.tags
                 )
                 resp = namespaces.create_namespace(client, namespace, None)
                 artifact = collections.upload_test_collection(
@@ -1016,6 +1022,7 @@ def main():
                     collection_name=collection_name,
                     version=version,
                     path=path,
+                    tags=tags,
                 )
                 print(json.dumps(artifact))
             elif args.operation == "move":

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -1013,7 +1013,7 @@ def main():
                     args.collection_name,
                     args.version or "1.0.0",
                     args.path or "staging",
-                    args.tags
+                    args.tags or ["tools"]
                 )
                 resp = namespaces.create_namespace(client, namespace, None)
                 artifact = collections.upload_test_collection(


### PR DESCRIPTION
This PR makes it convenient to upload test collections with specific tags by accepting tags as an argument in the upload command.

### Test:
```bash
pip3 install -e .
```
With galaxy_ng running, upload a test collection with custom tags:
```
galaxykit -u <username> -p <password> -s "http://localhost:5001/api/automation-hub/" 
    collection upload <namespace> <collection_name> --tags tag1 tag2 tag3
```
A test collection with tags tag1 tag2 and tag3 should be uploaded.