### PR TITLE
Add galaxykit collection upload --skip-upload, --template

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -100,6 +100,9 @@ class GalaxyClient:
         self._container_tls_verify = container_tls_verify
         self.gw_root_url = gw_root_url
 
+        if not https_verify:
+            requests.packages.urllib3.disable_warnings()
+
         if auth and not github_social_auth and not gw_auth:
             if isinstance(auth, dict):
                 self.username = auth.get("username")

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -106,7 +106,9 @@ def upload_test_collection(
     """
     Uploads a test collection generated with orionutils
     """
-    artifact = create_test_collection(namespace or client.username, collection_name, version, tags)
+    artifact = create_test_collection(
+        namespace or client.username, collection_name, version, tags
+    )
     return upload_and_wait(client, artifact, path)
 
 
@@ -132,6 +134,7 @@ def upload_and_wait(
         "version": artifact.version,
         "published": artifact.published,
     }
+
 
 def upload_artifact(
     client,

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -81,11 +81,14 @@ def save_test_collection(
     collection_name=None,
     version="1.0.0",
     tags=["tools"],
+    template="skeleton",
 ):
     """
     Saves (locally) a test collection generated with orionutils
     """
-    artifact = create_test_collection(namespace, collection_name, version, tags)
+    artifact = create_test_collection(
+        namespace, collection_name, version, tags, template
+    )
     return {
         "namespace": artifact.namespace,
         "name": artifact.name,
@@ -102,12 +105,13 @@ def upload_test_collection(
     version="1.0.0",
     path="staging",
     tags=["tools"],
+    template="skeleton",
 ):
     """
     Uploads a test collection generated with orionutils
     """
     artifact = create_test_collection(
-        namespace or client.username, collection_name, version, tags
+        namespace or client.username, collection_name, version, tags, template
     )
     return upload_and_wait(client, artifact, path)
 

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -237,6 +237,18 @@ def upload_artifact(
     return resp
 
 
+def approve_collection(client, namespace, collection_name, version):
+    return move_or_copy_collection(
+        client,
+        namespace,
+        collection_name,
+        version,
+        source="staging",
+        destination="published",
+        operation="move",
+    )
+
+
 def move_or_copy_collection(
     client,
     namespace,
@@ -296,6 +308,15 @@ def deprecate_collection(client, namespace, collection, repository):
     logger.debug(f"Deprecating {collection} in {namespace} on {client.galaxy_root}")
     url = f"v3/plugin/ansible/content/{repository}/collections/index/{namespace}/{collection}/"
     body = {"deprecated": True}
+    resp = client.patch(url, body)
+    wait_for_task(client, resp)
+    return resp
+
+
+def undeprecate_collection(client, namespace, collection, repository):
+    logger.debug(f"Undeprecating {collection} in {namespace} on {client.galaxy_root}")
+    url = f"v3/plugin/ansible/content/{repository}/collections/index/{namespace}/{collection}/"
+    body = {"deprecated": False}
     resp = client.patch(url, body)
     wait_for_task(client, resp)
     return resp

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -121,7 +121,7 @@ def upload_and_wait(
     artifact,
     path,
 ):
-    upload_resp_url = upload_artifact(client, artifact, path=path)["task"]
+    upload_resp_url = upload_artifact(None, client, artifact, path=path)["task"]
 
     ready = False
     state = ""
@@ -141,6 +141,7 @@ def upload_and_wait(
 
 
 def upload_artifact(
+    config,
     client,
     artifact,
     hash=True,
@@ -152,6 +153,7 @@ def upload_artifact(
     """
     Publishes a collection to a Galaxy server and returns the import task URI.
 
+    :param config: unused, left for compatibility
     :param client: a GalaxyClient object. Must be authenticated.
     :param artifact: the collection artifact to be uploaded. Expects structure to be that
         of collections produced using the orionutils build_collection function.

--- a/galaxykit/collections.py
+++ b/galaxykit/collections.py
@@ -89,6 +89,7 @@ def save_test_collection(
     artifact = create_test_collection(
         namespace, collection_name, version, tags, template
     )
+
     return {
         "namespace": artifact.namespace,
         "name": artifact.name,
@@ -113,25 +114,10 @@ def upload_test_collection(
     artifact = create_test_collection(
         namespace or client.username, collection_name, version, tags, template
     )
-    return upload_and_wait(client, artifact, path)
 
+    resp = upload_artifact(None, client, artifact, path=path)
+    wait_for_task(client, resp)
 
-def upload_and_wait(
-    client,
-    artifact,
-    path,
-):
-    upload_resp_url = upload_artifact(None, client, artifact, path=path)["task"]
-
-    ready = False
-    state = ""
-    while not ready:
-        sleep(1)
-        task_resp = client.get(upload_resp_url)
-        state = task_resp["state"]
-        ready = state in ["completed", "failed"]
-    if state == "failed":
-        raise GalaxyClientError(json.dumps(task_resp))
     return {
         "namespace": artifact.namespace,
         "name": artifact.name,

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -327,6 +327,9 @@ KIND_OPS = {
     "registry": {
         "help": "Remote Registry",
         "ops": {
+            "list": {
+                "args": None,
+            },
             "delete": {
                 "args": {
                     "name": {},
@@ -919,7 +922,16 @@ def main():
                         sys.exit(EXIT_NOT_FOUND)
 
         elif args.kind == "registry":
-            if args.operation == "delete":
+            if args.operation == "list":
+                try:
+                    resp = registries.list_registries(client)
+                    for name in map(lambda r: r["name"], resp):
+                        print(name)
+                except ValueError as e:
+                    if not args.ignore:
+                        logger.error(e)
+                        sys.exit(EXIT_NOT_FOUND)
+            elif args.operation == "delete":
                 name = args.name
                 try:
                     resp = registries.delete_registry(client, name)

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -97,6 +97,11 @@ KIND_OPS = {
                         "nargs": "*",
                         "default": None,
                     },
+                    "--skip-upload": {
+                        "help": "Save to a local file instead of uploading.",
+                        "action": "store_true",
+                        "default": False,
+                    },
                 },
             },
             "move": {
@@ -1008,22 +1013,31 @@ def main():
             if args.operation == "list":
                 print(json.dumps(collections.get_collection_list(client)))
             elif args.operation == "upload":
-                namespace, collection_name, version, path, tags = (
+                namespace, collection_name, version, path, tags, skip_upload = (
                     args.namespace or client.username,
                     args.collection_name,
                     args.version or "1.0.0",
                     args.path or "staging",
                     args.tags or ["tools"],
+                    args.skip_upload or False,
                 )
-                resp = namespaces.create_namespace(client, namespace, None)
-                artifact = collections.upload_test_collection(
-                    client,
-                    namespace=namespace,
-                    collection_name=collection_name,
-                    version=version,
-                    path=path,
-                    tags=tags,
-                )
+                if not skip_upload:
+                    namespaces.create_namespace(client, namespace, None)
+                    artifact = collections.upload_test_collection(
+                        client,
+                        namespace=namespace,
+                        collection_name=collection_name,
+                        version=version,
+                        path=path,
+                        tags=tags,
+                    )
+                else:
+                    artifact = collections.save_test_collection(
+                        namespace=namespace,
+                        collection_name=collection_name,
+                        version=version,
+                        tags=tags,
+                    )
                 print(json.dumps(artifact))
             elif args.operation == "move":
                 namespace, collection_name, version, source, destination = (

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -159,6 +159,27 @@ KIND_OPS = {
                     "collection_name": {},
                 },
             },
+            "approve": {
+                "args": {
+                    "namespace": {},
+                    "collection_name": {},
+                    "version": {},
+                },
+            },
+            "deprecate": {
+                "args": {
+                    "namespace": {},
+                    "collection_name": {},
+                    "repository": {"nargs": "?", "default": "published"},
+                },
+            },
+            "undeprecate": {
+                "args": {
+                    "namespace": {},
+                    "collection_name": {},
+                    "repository": {"nargs": "?", "default": "published"},
+                },
+            },
         },
     },
     "namespace": {
@@ -1145,6 +1166,42 @@ def main():
                     if not args.ignore:
                         logger.error(e)
                         sys.exit(EXIT_NOT_FOUND)
+            elif args.operation == "approve":
+                namespace, collection_name, version = (
+                    args.namespace,
+                    args.collection_name,
+                    args.version,
+                )
+                collections.approve_collection(
+                    client,
+                    namespace,
+                    collection_name,
+                    version,
+                )
+            elif args.operation == "deprecate":
+                namespace, collection_name, repository = (
+                    args.namespace,
+                    args.collection_name,
+                    args.repository or "published",
+                )
+                collections.deprecate_collection(
+                    client,
+                    namespace,
+                    collection_name,
+                    repository,
+                )
+            elif args.operation == "undeprecate":
+                namespace, collection_name, repository = (
+                    args.namespace,
+                    args.collection_name,
+                    args.repository or "published",
+                )
+                collections.undeprecate_collection(
+                    client,
+                    namespace,
+                    collection_name,
+                    repository,
+                )
         elif args.kind == "url":
             if args.operation == "get":
                 url = args.url

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -102,6 +102,11 @@ KIND_OPS = {
                         "action": "store_true",
                         "default": False,
                     },
+                    "--template": {
+                        "help": "orionutils collection template",
+                        "nargs": "?",
+                        "default": "skeleton",
+                    },
                 },
             },
             "move": {
@@ -1013,13 +1018,22 @@ def main():
             if args.operation == "list":
                 print(json.dumps(collections.get_collection_list(client)))
             elif args.operation == "upload":
-                namespace, collection_name, version, path, tags, skip_upload = (
+                (
+                    namespace,
+                    collection_name,
+                    version,
+                    path,
+                    tags,
+                    skip_upload,
+                    template,
+                ) = (
                     args.namespace or client.username,
                     args.collection_name,
                     args.version or "1.0.0",
                     args.path or "staging",
                     args.tags or ["tools"],
                     args.skip_upload or False,
+                    args.template or "skeleton",
                 )
                 if not skip_upload:
                     namespaces.create_namespace(client, namespace, None)
@@ -1030,6 +1044,7 @@ def main():
                         version=version,
                         path=path,
                         tags=tags,
+                        template=template,
                     )
                 else:
                     artifact = collections.save_test_collection(
@@ -1037,6 +1052,7 @@ def main():
                         collection_name=collection_name,
                         version=version,
                         tags=tags,
+                        template=template,
                     )
                 print(json.dumps(artifact))
             elif args.operation == "move":

--- a/galaxykit/registries.py
+++ b/galaxykit/registries.py
@@ -39,3 +39,12 @@ def create_registry(client, name, url):
         "url": url,
     }
     return client.post(post_url, registry)
+
+
+def list_registries(client):
+    """
+    List registries
+    """
+    url = f"_ui/v1/execution-environments/registries/?limit=100"
+    resp = client.get(url)
+    return resp["data"]

--- a/galaxykit/utils.py
+++ b/galaxykit/utils.py
@@ -3,7 +3,6 @@ import logging
 import json
 import re
 import time
-from urllib import request
 from urllib.parse import urljoin
 
 import requests


### PR DESCRIPTION
with `--skip-upload`, galaxykit just creates the file and returns the filename, without trying to upload it.

intended for generating artifacts for cypress e2e to upload, to test the UI paths


```
$ galaxykit collection upload --skip-upload
{"namespace": "admin", "name": "collection_dep_a_pntqbywn", "version": "1.0.0", "published": false, "filename": "/tmp/home/himdel/.local/lib/python3.11/site-packages/orionutils/collections/skeleton/admin-collection_dep_a_pntqbywn-1.0.0.tar.gz"}

$ ls -l /tmp/home/himdel/.local/lib/python3.11/site-packages/orionutils/collections/skeleton/admin-collection_dep_a_pntqbywn-1.0.0.tar.gz
-rw-r--r-- 1 himdel himdel 1582 Jan 21 20:13 /tmp/home/himdel/.local/lib/python3.11/site-packages/orionutils/collections/skeleton/admin-collection_dep_a_pntqbywn-1.0.0.tar.gz
```

(`... | jq .filename` to get just the filename)

Cc @ZitaNemeckova @akus062381 @nixocio

(the collection template lives in https://github.com/peaqe/orion-utils/tree/master/orionutils/collections/skeleton)

---

Also allow `--template` to allow picking templates other than `skeleton`, from https://github.com/peaqe/orion-utils/tree/master/orionutils/collections

---

Also,

`collection approve namespace name version`
`collection deprecate namespace name repository`
`collection undeprecate namespace name repository`

---

Also.. 
When `-c` is used, disable the urllib warning:

```
/usr/lib/python3/dist-packages/urllib3/connectionpool.py:1062: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/usr/lib/python3/dist-packages/urllib3/connectionpool.py:1062: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
```