### PR TITLE
galaxykit collection upload --skip-upload: don't instantiate client

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -1,6 +1,7 @@
 """
 client.py contains the wrapping interface for all the other modules (aside from cli.py)
 """
+
 import logging
 import platform
 import sys

--- a/galaxykit/command.py
+++ b/galaxykit/command.py
@@ -691,16 +691,17 @@ def main():
     if args.kind == "greet":
         creds = None
 
-    if args.gw_root_url:
-        client = GalaxyClient(
-            args.server,
-            creds,
-            https_verify=https_verify,
-            gw_auth=True,
-            gw_root_url=args.gw_root_url,
-        )
-    else:
-        client = GalaxyClient(args.server, creds, https_verify=https_verify)
+    if args.kind != "collection" or args.operation != "upload" or not args.skip_upload:
+        if args.gw_root_url:
+            client = GalaxyClient(
+                args.server,
+                creds,
+                https_verify=https_verify,
+                gw_auth=True,
+                gw_root_url=args.gw_root_url,
+            )
+        else:
+            client = GalaxyClient(args.server, creds, https_verify=https_verify)
 
     resp = None
 

--- a/galaxykit/repositories.py
+++ b/galaxykit/repositories.py
@@ -50,9 +50,11 @@ def create_repository(
 
     registry = {"name": name, "private": private}
     registry.update({"description": description}) if description is not None else False
-    registry.update(
-        {"pulp_labels": {"hide_from_search": ""}}
-    ) if hide_from_search is not False else False
+    (
+        registry.update({"pulp_labels": {"hide_from_search": ""}})
+        if hide_from_search is not False
+        else False
+    )
 
     if pipeline:
         registry["pulp_labels"] = {"pipeline": pipeline}

--- a/galaxykit/utils.py
+++ b/galaxykit/utils.py
@@ -1,4 +1,5 @@
 """Utility functions"""
+
 import logging
 import re
 import time


### PR DESCRIPTION
We don't need `client` when using galaxykit just to create a collection tarball.

Make sure `galaxykit collection upload --skip-upload` doesn't connect to the server.