### PR TITLE
py312 compatibility

### DIFF
--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -5,12 +5,15 @@ on: [ 'pull_request' ]
 jobs:
   test_run:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
 
       - name: install dependencies
         run: pip install --user --upgrade --editable .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "simplejson",
     "orionutils",
     "pyyaml",
+    "setuptools",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
```
$ galaxykit collection --help
Traceback (most recent call last):
  File "/home/jtanner/workspace/github/jctanner.redhat/2024_11_07_gk_filter_plugins/venv/bin/galaxykit", line 5, in <module>
    from galaxykit.command import main
  File "/home/jtanner/workspace/github/jctanner.redhat/2024_11_07_gk_filter_plugins/galaxykit/galaxykit/__init__.py", line 2, in <module>
    from .client import GalaxyClient
  File "/home/jtanner/workspace/github/jctanner.redhat/2024_11_07_gk_filter_plugins/galaxykit/galaxykit/client.py", line 13, in <module>
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'
```