### PR TITLE
Make sure `Referer` header is always set

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -268,6 +268,10 @@ class GalaxyClient:
         galaxy_ng_version = self.server_version
         return parse_version(galaxy_ng_version) >= parse_version(RBAC_VERSION)
 
+    def make_sure_referer_is_set(self, url):
+        if "Referer" not in self.headers:
+            self.headers.update({ "Referer": url }) 
+
     def _http(self, method, path, *args, **kwargs):
 
         # ensure we have a valid session instead of hoping
@@ -275,6 +279,9 @@ class GalaxyClient:
         self.check_or_refresh_gateway_session()
 
         url = urljoin(self.galaxy_root.rstrip("/") + "/", path)
+
+        self.make_sure_referer_is_set(url)
+
         headers = kwargs.pop("headers", self.headers)
         parse_json = kwargs.pop("parse_json", True)
         relogin = kwargs.pop("relogin", True)

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -268,9 +268,13 @@ class GalaxyClient:
         galaxy_ng_version = self.server_version
         return parse_version(galaxy_ng_version) >= parse_version(RBAC_VERSION)
 
-    def make_sure_referer_is_set(self, url):
-        if "Referer" not in self.headers:
-            self.headers.update({ "Referer": url }) 
+    def make_sure_referer_is_set(self, headers, url):
+        """Return headers with Referer set, if not already set."""
+        headers_with_referer = headers.copy()
+        if "Referer" not in headers_with_referer:
+            headers_with_referer.update({ "Referer": url }) 
+        
+        return headers_with_referer
 
     def _http(self, method, path, *args, **kwargs):
 
@@ -280,9 +284,9 @@ class GalaxyClient:
 
         url = urljoin(self.galaxy_root.rstrip("/") + "/", path)
 
-        self.make_sure_referer_is_set(url)
-
         headers = kwargs.pop("headers", self.headers)
+        headers = self.make_sure_referer_is_set(headers, url)
+
         parse_json = kwargs.pop("parse_json", True)
         relogin = kwargs.pop("relogin", True)
         resp = send_request_with_retry_if_504(

--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -285,7 +285,8 @@ class GalaxyClient:
         url = urljoin(self.galaxy_root.rstrip("/") + "/", path)
 
         headers = kwargs.pop("headers", self.headers)
-        headers = self.make_sure_referer_is_set(headers, url)
+        if headers is not None:
+            headers = self.make_sure_referer_is_set(headers, url)
 
         parse_json = kwargs.pop("parse_json", True)
         relogin = kwargs.pop("relogin", True)


### PR DESCRIPTION
Issue:[AAP-48940](https://issues.redhat.com/browse/AAP-48940)

```
[2025-07-07T11:11:56.590Z]         raise GalaxyClientError(resp, *json_data["errors"])
[2025-07-07T11:11:56.590Z]     galaxykit.utils.GalaxyClientError: {'status': '404', 'code': 'not_found', 'title': 'Not found.'}
[2025-07-07T11:11:56.590Z]     DEBUG    galaxykit.utils:namespaces.py:23 Creating namespace autohubtest2. Request body {'name': 'autohubtest2', 'groups': []}
[2025-07-07T11:11:56.590Z]     DEBUG    galaxykit.client:client.py:392 Request headers: {'Accept': 'application/json', 'Cookie': 'csrftoken=rX0oMLyuJBlvfHNVdypjfmP1c2ERmajF; gateway_sessionid=7rtbyge5pvujm1xgbmhobhijff70r1vg', 'X-CSRFToken': 'rX0oMLyuJBlvfHNVdypjfmP1c2ERmajF', 'Content-Type': 'application/json;charset=utf-8', 'Content-Length': '38'}
[2025-07-07T11:11:56.591Z]     DEBUG    galaxykit.client:client.py:393 Request body: b'{"name": "autohubtest2", "groups": []}'
[2025-07-07T11:11:56.591Z]     DEBUG    urllib3.connectionpool:connectionpool.py:1049 Starting new HTTPS connection (1): 34.239.106.56:443
[2025-07-07T11:11:56.591Z]     DEBUG    urllib3.connectionpool:connectionpool.py:544 [https://34.239.106.56:443](https://34.239.106.56/) "POST /api/galaxy/v3/namespaces/ HTTP/1.1" 403 65
[2025-07-07T11:11:56.591Z]     DEBUG    root:client.py:341 {'details': 'CSRF Failed: Referer checking failed - no Referer.'}
```