### PR TITLE
Support custom `gateway_sessionid`

### DIFF
--- a/galaxykit/gw_auth_client.py
+++ b/galaxykit/gw_auth_client.py
@@ -74,11 +74,20 @@ class GatewayAuthClient:
         match = re.search(token_pattern, response.text)
         return match.group(1)
 
+    def parse_custom_gateway_sessionid(self, cookies):
+        """Support gateway_sessionid cookie with optional suffix. 
+        For example the aap-dev 2.7, the HTTP header key is gateway_sessionid44927.
+        """
+        for cookie in cookies:
+                if cookie.name.startswith("gateway_sessionid"):
+                    return cookie.name, cookie.value
+        return None, None
+
     def get_cookies_from_response(self, response):
         self.csrftoken = response.cookies["csrftoken"]
-        gateway_sessionid = response.cookies["gateway_sessionid"]
+        custom_sessionid, gateway_sessionid = self.parse_custom_gateway_sessionid(response.cookies)
         return {
             "Accept": "application/json",
-            "Cookie": f"csrftoken={self.csrftoken}; gateway_sessionid={gateway_sessionid}",
+            "Cookie": f"csrftoken={self.csrftoken}; {custom_sessionid}={gateway_sessionid}",
             "X-CSRFToken": self.csrftoken,
         }

--- a/galaxykit/gw_auth_client.py
+++ b/galaxykit/gw_auth_client.py
@@ -75,17 +75,19 @@ class GatewayAuthClient:
         return match.group(1)
 
     def parse_custom_gateway_sessionid(self, cookies):
-        """Support gateway_sessionid cookie with optional suffix. 
+        """Support gateway_sessionid cookie with optional suffix.
         For example the aap-dev 2.7, the HTTP header key is gateway_sessionid44927.
         """
         for cookie in cookies:
-                if cookie.name.startswith("gateway_sessionid"):
-                    return cookie.name, cookie.value
+            if cookie.name.startswith("gateway_sessionid"):
+                return cookie.name, cookie.value
         return None, None
 
     def get_cookies_from_response(self, response):
         self.csrftoken = response.cookies["csrftoken"]
-        custom_sessionid, gateway_sessionid = self.parse_custom_gateway_sessionid(response.cookies)
+        custom_sessionid, gateway_sessionid = self.parse_custom_gateway_sessionid(
+            response.cookies
+        )
         return {
             "Accept": "application/json",
             "Cookie": f"csrftoken={self.csrftoken}; {custom_sessionid}={gateway_sessionid}",


### PR DESCRIPTION
Add support to the `GatewayAuthClient` class for custom gateway_sessionid headers. For example aap-dev 2.7 appends port number to the header attribute.
```
curl -v http://localhost:44927/api/gateway/v1/login/ \
    -H "Referer: http://localhost:44927/login" \
    -H "Cookie: csrftoken=<csrftoken>" \
    -H "X-Csrftoken: <csrftoken> \
    -d "username=<usr>password=<pwd> 2>&1 | grep gateway_sessionid
< set-cookie: gateway_sessionid44927=jwbb69k...
```