### PR TITLE
fix: handle suffixed gateway_sessionid in session expiry tracking

### DIFF
--- a/galaxykit/client.py
+++ b/galaxykit/client.py
@@ -195,7 +195,7 @@ class GalaxyClient:
         self.headers = self.gw_client.headers
 
         for cookie in self.response.cookies:
-            if cookie.name != "gateway_sessionid":
+            if not cookie.name.startswith("gateway_sessionid"):
                 continue
             self.session_expires = cookie.expires
             break


### PR DESCRIPTION
## Summary
- Commit 6d6def8 (`Support custom gateway_sessionid (#131)`) fixed `gw_auth_client.get_cookies_from_response` to use `startswith("gateway_sessionid")` for suffixed cookie names in 2.7+
- But `GalaxyClient.check_or_refresh_gateway_session` still uses an exact match (`cookie.name != "gateway_sessionid"`), so `session_expires` is never set on suffixed deployments
- This causes every `_http()` call to re-authenticate, overwriting any intentionally corrupted headers (breaking Gateway auth tests)
- One-line fix: use `startswith` to match the same pattern as `parse_custom_gateway_sessionid`

## Test plan
- [ ] Run Galaxy-NG Gateway auth tests (`test_gateway_auth_admin_gateway_sessionid`, `test_gateway_token_auth`, `test_gateway_create_ns_csrftoken`) against a 2.7 deployment with suffixed cookie
- [ ] Verify session expiry tracking works (no unnecessary re-logins)

Fixes: AAP-66185

🤖 Generated with [Claude Code](https://claude.com/claude-code)